### PR TITLE
Part 4: History

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dendriform
+o# dendriform
 
 [![npm](https://img.shields.io/npm/v/dendriform.svg)](https://www.npmjs.com/package/dendriform) ![Master build](https://github.com/92green/dendriform/workflows/CI/badge.svg?branch=master) ![Maturity: Early Days](https://img.shields.io/badge/Maturity-Early%20days-yellow) ![Coolness Reasonable](https://img.shields.io/badge/Coolness-Reasonable-blue) 
 
@@ -520,7 +520,7 @@ function MyComponent(props) {
 };
 ```
 
-The `.go()` function can also be used to perform undo and repo operations.
+The `.go()` function can also be used to perform undo and redo operations.
 
 ```js
 form.go(-1); // equivalent to form.undo()

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ History can be navigated by calling `.undo()` and `.redo()` on any form. It does
 ```js
 function MyComponent(props) {
 
-    const form = useDendriform(() => ({name: 'Ben'});
+    const form = useDendriform(() => ({name: 'Ben'}));
 
     return <div>
         {form.render('name', form => (
@@ -534,7 +534,7 @@ You can find if the form is able to undo or redo using `.history`, or by using t
 ```js
 function MyComponent(props) {
 
-    const form = useDendriform(() => ({name: 'Ben'});
+    const form = useDendriform(() => ({name: 'Ben'}));
 
     return <div>
         {form.render('name', form => (

--- a/packages/dendriform-demo/pages/index.tsx
+++ b/packages/dendriform-demo/pages/index.tsx
@@ -76,7 +76,7 @@ export default function Main(): React.ReactElement {
                 {name: 'oh noo!'}
             ]
         });
-    });
+    }, {history: 100});
 
     form.useChange((value, details) => {
         // eslint-disable-next-line no-console
@@ -107,6 +107,13 @@ export default function Main(): React.ReactElement {
             <Box p={2}>
                 Tick: {tick} seconds
             </Box>
+            {form.render(form => {
+                const {canUndo, canRedo} = form.useHistory();
+                return <Box p={2}>
+                    <button onClick={() => form.undo()} disabled={!canUndo}>Undo</button>
+                    <button onClick={() => form.redo()} disabled={!canRedo}>Redo</button>
+                </Box>;
+            })}
             <Box p={2}>
                 <strong>Text inputs with debounce</strong><br/>
             </Box>
@@ -284,6 +291,7 @@ const TEXT = `
 - opt-in es6 class compatibility ✅
 - onChange ✅
 - ability to be controlled by higher up data sources ✅
+- undo / redo ✅
 - allow multiple sets in a row to be squashed together ✅
 - array element mutations ✅
 - able to output JSON patches for proper concurrent editing ✅
@@ -291,7 +299,6 @@ const TEXT = `
 
 // SOON
 
-- undo / redo
 - derived data computation
 - validation
   - need to make it possible to prefill errors from back end response

--- a/packages/dendriform/.size-limit.js
+++ b/packages/dendriform/.size-limit.js
@@ -2,7 +2,7 @@ module.exports = [
     {
         name: 'everything combined',
         path: "dist/dendriform.esm.js",
-        limit: "7.6 KB",
+        limit: "7.7 KB",
         ignore: ['react', 'react-dom']
     },
     {
@@ -16,7 +16,7 @@ module.exports = [
         name: 'Dendriform',
         path: "dist/dendriform.esm.js",
         import: "{ Dendriform }",
-        limit: "6.9 KB",
+        limit: "7.1 KB",
         ignore: ['react', 'react-dom']
     },
     {

--- a/packages/dendriform/.size-limit.js
+++ b/packages/dendriform/.size-limit.js
@@ -2,7 +2,7 @@ module.exports = [
     {
         name: 'everything combined',
         path: "dist/dendriform.esm.js",
-        limit: "7.4 KB",
+        limit: "7.6 KB",
         ignore: ['react', 'react-dom']
     },
     {
@@ -16,7 +16,7 @@ module.exports = [
         name: 'Dendriform',
         path: "dist/dendriform.esm.js",
         import: "{ Dendriform }",
-        limit: "6.8 KB",
+        limit: "6.9 KB",
         ignore: ['react', 'react-dom']
     },
     {

--- a/packages/dendriform/.size-limit.js
+++ b/packages/dendriform/.size-limit.js
@@ -2,7 +2,7 @@ module.exports = [
     {
         name: 'everything combined',
         path: "dist/dendriform.esm.js",
-        limit: "7.7 KB",
+        limit: "7.8 KB",
         ignore: ['react', 'react-dom']
     },
     {
@@ -16,7 +16,7 @@ module.exports = [
         name: 'Dendriform',
         path: "dist/dendriform.esm.js",
         import: "{ Dendriform }",
-        limit: "7.1 KB",
+        limit: "7.2 KB",
         ignore: ['react', 'react-dom']
     },
     {

--- a/packages/dendriform/README.md
+++ b/packages/dendriform/README.md
@@ -527,6 +527,15 @@ function MyComponent(props) {
 };
 ```
 
+The `.go()` function can also be used to perform undo and repo operations.
+
+```js
+form.go(-1); // equivalent to form.undo()
+form.go(1); // equivalent to form.redo()
+form.go(-3); // equivalent to form.undo() called 3 times in a row
+form.go(0); // does nothing
+```
+
 You can find if the form is able to undo or redo using `.history`, or by using the `.useHistory()` hook if you're inside a React component's render method. These both return an object `{canUndo: boolean, canRedo: boolean}`. This can be used to disable undo and redo buttons.
 
 ```js

--- a/packages/dendriform/README.md
+++ b/packages/dendriform/README.md
@@ -507,7 +507,7 @@ History can be navigated by calling `.undo()` and `.redo()` on any form. It does
 ```js
 function MyComponent(props) {
 
-    const form = useDendriform(() => ({name: 'Ben'});
+    const form = useDendriform(() => ({name: 'Ben'}));
 
     return <div>
         {form.render('name', form => (
@@ -534,7 +534,7 @@ You can find if the form is able to undo or redo using `.history`, or by using t
 ```js
 function MyComponent(props) {
 
-    const form = useDendriform(() => ({name: 'Ben'});
+    const form = useDendriform(() => ({name: 'Ben'}));
 
     return <div>
         {form.render('name', form => (

--- a/packages/dendriform/README.md
+++ b/packages/dendriform/README.md
@@ -198,6 +198,8 @@ Array element forms can also opt-in to updates regarding their indexes using the
 
 If you'll be allowing users to re-order items in an array, then please note that you'll get better performance if array element components don't know about their indexes. If the `.useIndex()` hook is used, a element that has moved its position inside of its parent array will need to update, even if it is otherwise unchanged.
 
+The `.index` property is available for usages outside of React.
+
 ```js
 function MyComponent(props) {
     const form = useDendriform({
@@ -491,9 +493,63 @@ function MyComponent(props) {
 }
 ```
 
+### History
 
+Dendriform can keep track of the history of changes and supports undo and redo. Activate this by specifying the maximum number of undos you would like to allow in the options object when creating a form.
 
+History items consist of immer patches that have been optimised, so they take up very little memory in comparison to full state snapshots.
 
+```js
+const form = new Dendriform({name: 'Bill'}, {history: 50});
+// ...
+
+function MyComponent(props) {
+    const form = useDendriform({name: 'Ben'}, {history: 50});
+    // ...
+}
+```
+
+History can be navigated by calling `.undo()` and `.redo()` on any form. It does not matter if you are calling these on the top level form or any branched form, the effect will be the same.
+
+```js
+function MyComponent(props) {
+
+    const form = useDendriform(() => ({name: 'Ben'});
+
+    return <div>
+        {form.render('name', form => (
+            <label>name: <input {...useInput(form, 150)} /></label>
+        ))}
+
+        <button onClick={form.undo}>Undo</button>
+        <button onClick={form.redo}>Redo</button>
+    </div>;
+};
+```
+
+You can find if the form is able to undo or redo using `.history`, or by using the `.useHistory()` hook if you're inside a React component's render method. These both return an object `{canUndo: boolean, canRedo: boolean}`. This can be used to disable undo and redo buttons.
+
+```js
+function MyComponent(props) {
+
+    const form = useDendriform(() => ({name: 'Ben'});
+
+    return <div>
+        {form.render('name', form => (
+            <label>name: <input {...useInput(form, 150)} /></label>
+        ))}
+
+        {form.render(form => {
+            const {canUndo, canRedo} = form.useHistory();
+            // this function will only re-render if canUndo or canRedo changes
+            return <>
+                <button onClick={form.undo} disable={!canUndo}>Undo</button>
+                <button onClick={form.redo} disable={!canRedo}>Redo</button>
+            </>;
+        })}
+    </div>;
+};
+```
 
 ## Development
 

--- a/packages/dendriform/README.md
+++ b/packages/dendriform/README.md
@@ -520,7 +520,7 @@ function MyComponent(props) {
 };
 ```
 
-The `.go()` function can also be used to perform undo and repo operations.
+The `.go()` function can also be used to perform undo and redo operations.
 
 ```js
 form.go(-1); // equivalent to form.undo()

--- a/packages/dendriform/src/BufferTime.ts
+++ b/packages/dendriform/src/BufferTime.ts
@@ -6,6 +6,7 @@ export class BufferTime<V> {
     callback: Callback<V>;
     buffer: V[] = [];
     time = 0;
+    timerId = -1;
 
     constructor(callback: Callback<V>) {
         this.callback = callback;
@@ -13,12 +14,13 @@ export class BufferTime<V> {
 
     push(value: V): void {
         if(this.buffer.length === 0) {
-            setTimeout(() => this.flush(), this.time);
+            this.timerId = window.setTimeout(() => this.flush(), this.time);
         }
         this.buffer.push(value);
     }
 
     flush(): void {
+        window.clearTimeout(this.timerId);
         this.callback(this.buffer);
         this.buffer = [];
     }

--- a/packages/dendriform/src/Dendriform.tsx
+++ b/packages/dendriform/src/Dendriform.tsx
@@ -125,7 +125,7 @@ class Core<C> {
         const path = this.getPath(id);
         if(!path) return -1;
         const [key] = path.slice(-1);
-        if(typeof key !== 'number') die(3, path);
+        if(typeof key !== 'number') die(4, path);
         return key;
     };
 

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -99,7 +99,8 @@ describe(`Dendriform`, () => {
             const firstHook = renderHook(() => useDendriform(['a','b','c']));
 
             const form = firstHook.result.current;
-            const {result} = renderHook(() => form.branch(0).useIndex());
+            const elementForm = form.branch(0);
+            const {result} = renderHook(() => elementForm.useIndex());
             expect(result.current).toBe(0);
 
             act(() => {
@@ -111,6 +112,7 @@ describe(`Dendriform`, () => {
 
             // should have updated index
             expect(result.current).toBe(1);
+            expect(elementForm.index).toBe(1);
 
             act(() => {
                 form.set(draft => {

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -291,6 +291,58 @@ describe(`Dendriform`, () => {
             expect(form.value).toBe(789);
         });
 
+        test(`should go`, () => {
+            const form = new Dendriform(['a'], {history: 100});
+
+            form.set(draft => void draft.push('b'));
+            form.core.changeBuffer.flush();
+
+            form.set(draft => void draft.push('c'));
+            form.core.changeBuffer.flush();
+
+            form.set(draft => void draft.push('d'));
+            form.core.changeBuffer.flush();
+
+            expect(form.value).toEqual(['a','b','c','d']);
+
+            form.go(-1);
+
+            expect(form.value).toEqual(['a','b','c']);
+
+            form.go(-2);
+
+            expect(form.value).toEqual(['a']);
+
+            form.go(1);
+
+            expect(form.value).toEqual(['a','b']);
+
+            form.go(2);
+
+            expect(form.value).toEqual(['a','b','c','d']);
+
+            form.go(-100);
+
+            expect(form.value).toEqual(['a']);
+
+            form.go(100);
+
+            expect(form.value).toEqual(['a','b','c','d']);
+        });
+
+        test(`should go nowhere`, () => {
+            const form = new Dendriform('a', {history: 100});
+
+            form.set('b');
+            form.core.changeBuffer.flush();
+
+            expect(form.value).toBe('b');
+
+            form.go(0);
+
+            expect(form.value).toBe('b');
+        });
+
         test(`should undo merged changes`, () => {
             const form = new Dendriform(0, {history: 100});
 


### PR DESCRIPTION
See commit messages.
- Adds `form.undo()`, `form.redo()`, `form.go()`, `form.history`, `form.useHistory()`
- Adds `.index` which was missing from the last PR

### History

Dendriform can keep track of the history of changes and supports undo and redo. Activate this by specifying the maximum number of undos you would like to allow in the options object when creating a form.

History items consist of immer patches that have been optimised, so they take up very little memory in comparison to full state snapshots.

```js
const form = new Dendriform({name: 'Bill'}, {history: 50});
// ...

function MyComponent(props) {
    const form = useDendriform({name: 'Ben'}, {history: 50});
    // ...
}
```

History can be navigated by calling `.undo()` and `.redo()` on any form. It does not matter if you are calling these on the top level form or any branched form, the effect will be the same.

```js
function MyComponent(props) {

    const form = useDendriform(() => ({name: 'Ben'});

    return <div>
        {form.render('name', form => (
            <label>name: <input {...useInput(form, 150)} /></label>
        ))}

        <button onClick={form.undo}>Undo</button>
        <button onClick={form.redo}>Redo</button>
    </div>;
};
```

The `.go()` function can also be used to perform undo and repo operations.

```js
form.go(-1); // equivalent to form.undo()
form.go(1); // equivalent to form.redo()
form.go(-3); // equivalent to form.undo() called 3 times in a row
form.go(0); // does nothing
```

You can find if the form is able to undo or redo using `.history`, or by using the `.useHistory()` hook if you're inside a React component's render method. These both return an object `{canUndo: boolean, canRedo: boolean}`. This can be used to disable undo and redo buttons.

```js
function MyComponent(props) {

    const form = useDendriform(() => ({name: 'Ben'}));

    return <div>
        {form.render('name', form => (
            <label>name: <input {...useInput(form, 150)} /></label>
        ))}

        {form.render(form => {
            const {canUndo, canRedo} = form.useHistory();
            // this function will only re-render if canUndo or canRedo changes
            return <>
                <button onClick={form.undo} disable={!canUndo}>Undo</button>
                <button onClick={form.redo} disable={!canRedo}>Redo</button>
            </>;
        })}
    </div>;
};
```