### PR TITLE
ES6 values

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,10 +466,8 @@ form.branch(456).set('Janet');
 
 To modify a `Map`s value, support must be explicitly enabled by calling `enableMapSet()` [as immer's documentation describes(https://immerjs.github.io/immer/map-set).
 
-You should import `enableMapSet` from `dendriform` so you are guaranteed to enable Maps on the version of immer that dendriform uses.
-
 ```js
-import {enableMapSet} from 'dendriform';
+import {enableMapSet} from 'immer';
 
 enableMapSet();
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ npm install --save dendriform
 - [Rendering](#rendering)
 - [Rendering arrays](#rendering-arrays)
 - [Setting data](#setting-data)
-- [ES6 classes](#esr-classes)
+- [ES6 classes](#es6-classes)
+- [ES6 maps](#es6-maps)
 - [Form inputs](#form-inputs)
 - [Subscribing to changes](#subscribing-to-changes)
 - [Array operations](#array-operations)
@@ -130,7 +131,7 @@ function MyComponent(props) {
 }
 ```
 
-The value can be of any type, however only plain objects, arrays and [ES6 classes](#es6-classes) will be able to use [branching](#branching) to access and modify child values.
+The value can be of any type, however only plain objects, arrays, [ES6 classes](#es6-classes) and [ES6 maps](#es6-maps) will be able to use [branching](#branching) to access and modify child values.
 
 ### Values
 
@@ -439,6 +440,48 @@ const form = new Dendriform(person);
 form.branch('firstName').set('Janet');
 ```
 
+[Demo](http://dendriform.xyz#es6-classes)
+
+### ES6 maps
+
+ES6 maps can be stored in a form and its properties can be accessed using branch methods.
+
+```js
+const usersById = new Map();
+usersById.set(123, 'Harry');
+usersById.set(456, 'Larry');
+
+const form = new Dendriform(usersById);
+
+// form.branch(123).value will be 'Harry'
+```
+
+But by default you will not be able to modify this value.
+
+```js
+const form = new Dendriform(usersById);
+form.branch(456).set('Janet');
+// ^ throws an error
+```
+
+To modify a `Map`s value, support must be explicitly enabled by calling `enableMapSet()` [as immer's documentation describes(https://immerjs.github.io/immer/map-set).
+
+You should import `enableMapSet` from `dendriform` so you are guaranteed to enable Maps on the version of immer that dendriform uses.
+
+```js
+import {enableMapSet} from 'dendriform';
+
+enableMapSet();
+
+const usersById = new Map();
+usersById.set(123, 'Harry');
+usersById.set(456, 'Larry');
+
+const form = new Dendriform(usersById);
+form.branch(456).set('Janet');
+```
+
+[Demo](http://dendriform.xyz#es6-maps)
 
 ### Form inputs
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 
 
-Build feature-rich data-editing React UIs with great performance and not much code.
+Build feature-rich data-editing React UIs with great performance and little code.
 
 **[See the demos](http://dendriform.xyz)**
 
@@ -87,6 +87,7 @@ npm install --save dendriform
 - [Rendering](#rendering)
 - [Rendering arrays](#rendering-arrays)
 - [Setting data](#setting-data)
+- [ES6 classes](#esr-classes)
 - [Form inputs](#form-inputs)
 - [Subscribing to changes](#subscribing-to-changes)
 - [Array operations](#array-operations)
@@ -129,7 +130,7 @@ function MyComponent(props) {
 }
 ```
 
-The value can be of any type, however only plain objects and arrays will be able to use [branching](#branching) to access and modify child values.
+The value can be of any type, however only plain objects, arrays and [ES6 classes](#es6-classes) will be able to use [branching](#branching) to access and modify child values.
 
 ### Values
 
@@ -390,6 +391,55 @@ form.done();
 // form.value will update to become 3
 ```
 
+### ES6 classes
+
+ES6 classes can be stored in a form and its properties can be accessed using branch methods.
+
+```js
+class Person {
+    firstName = '';
+    lastName = '';
+}
+
+const person = new Person();
+person.firstName = 'Billy';
+person.lastName = 'Thump';
+
+const form = new Dendriform(person);
+
+// form.branch('firstName').value will be 'Billy'
+```
+
+But by default you will not be able to modify this value.
+
+```js
+const form = new Dendriform(person);
+form.branch('firstName').set('Janet');
+// ^ throws an error
+```
+
+To modify a class property, your class must have the `immerable` property on it [as immer's documentation describes(https://immerjs.github.io/immer/complex-objects).
+
+You should import `immerable` from `dendriform` so you are guaranteed to get the immerable symbol from the version of immer that dendriform uses.
+
+```js
+import {immerable} from 'dendriform';
+
+class Person {
+    firstName = '';
+    lastName = '';
+    [immerable] = true; // makes the class immerable
+}
+
+const person = new Person();
+person.firstName = 'Billy';
+person.lastName = 'Thump';
+
+const form = new Dendriform(person);
+form.branch('firstName').set('Janet');
+```
+
+
 ### Form inputs
 
 You can easily bind parts of your data to form inputs using `useInput()` and `useCheckbox()`. The props they return can be spread onto form elements. A debounce value (milliseconds) can also be provided to `useInput()` to prevent too many updates happening in a short space of time.
@@ -593,7 +643,7 @@ function MyComponent(props) {
 
 Dendriform can keep track of the history of changes and supports undo and redo. Activate this by specifying the maximum number of undos you would like to allow in the options object when creating a form.
 
-History items consist of immer patches that have been optimised, so they take up very little memory in comparison to full state snapshots.
+History items consist of [immer patches](https://immerjs.github.io/immer/patches) that have been optimised, so they take up very little memory in comparison to full state snapshots.
 
 ```js
 const form = new Dendriform({name: 'Bill'}, {history: 50});

--- a/packages/dendriform-demo/components/Demos.tsx
+++ b/packages/dendriform-demo/components/Demos.tsx
@@ -1,5 +1,5 @@
 import {useCallback, useEffect, useState, useRef, memo} from 'react';
-import {Dendriform, useDendriform, useInput, useCheckbox, useSync, array} from 'dendriform';
+import {Dendriform, useDendriform, useInput, useCheckbox, useSync, array, immerable} from 'dendriform';
 import {Box, Flex} from '../components/Layout';
 import {H2} from '../components/Text';
 import styled from 'styled-components';
@@ -433,6 +433,62 @@ function MyComponent(props) {
 
         <button onClick={add3nobuffer}>add 1, 3 times without buffering</button>
         <button onClick={add3buffer}>add 1, 3 times with buffering</button>
+    </div>;
+}
+`;
+
+//
+// es6 classes
+//
+
+class Person {
+    firstName = '';
+    lastName = '';
+    [immerable] = true;
+}
+
+function ES6Classes(): React.ReactElement {
+
+    const form = useDendriform(() => {
+        const person = new Person();
+        person.firstName = 'Billy';
+        person.lastName = 'Thump';
+        return person;
+    });
+
+    return <Region>
+        {form.render('firstName', form => (
+            <Region of="label">first name: <input {...useInput(form, 150)} /></Region>
+        ))}
+        {form.render('lastName', form => (
+            <Region of="label">last name: <input {...useInput(form, 150)} /></Region>
+        ))}
+    </Region>;
+}
+
+const ES6ClassesCode = `
+class Person {
+    firstName = '';
+    lastName = '';
+    [immerable] = true;
+}
+
+function MyComponent(props) {
+
+    const form = useDendriform(() => {
+        const person = new Person();
+        person.firstName = 'Billy';
+        person.lastName = 'Thump';
+        return person;
+    });
+
+    return <div>
+        {form.render('firstName', form => (
+            <label>first name: <input {...useInput(form, 150)} /></label>
+        ))}
+        {form.render('lastName', form => (
+            <label>last name: <input {...useInput(form, 150)} /></label>
+        ))}
     </div>;
 }
 `;
@@ -1366,6 +1422,12 @@ const DEMOS: DemoObject[] = [
         Demo: SettingDataBuffer,
         code: SettingDataBufferCode,
         anchor: 'buffer'
+    },
+    {
+        title: 'ES6 classes',
+        Demo: ES6Classes,
+        code: ES6ClassesCode,
+        anchor: 'es6-classes'
     },
     {
         title: 'Form inputs',

--- a/packages/dendriform-demo/components/Demos.tsx
+++ b/packages/dendriform-demo/components/Demos.tsx
@@ -1,11 +1,12 @@
 import {useCallback, useEffect, useState, useRef, memo} from 'react';
-import {Dendriform, useDendriform, useInput, useCheckbox, useSync, array, immerable, enableMapSet} from 'dendriform';
+import {Dendriform, useDendriform, useInput, useCheckbox, useSync, array, immerable} from 'dendriform';
 import {Box, Flex} from '../components/Layout';
 import {H2} from '../components/Text';
 import styled from 'styled-components';
 import {DragDropContext, Droppable, Draggable} from 'react-beautiful-dnd';
 import type {DropResult} from 'react-beautiful-dnd';
 import type {Draft} from 'immer';
+import {enableMapSet} from 'immer';
 import type {ThemeProps} from '../pages/_app';
 
 //

--- a/packages/dendriform-demo/components/Demos.tsx
+++ b/packages/dendriform-demo/components/Demos.tsx
@@ -1,5 +1,5 @@
 import {useCallback, useEffect, useState, useRef, memo} from 'react';
-import {Dendriform, useDendriform, useInput, useCheckbox, useSync, array, immerable} from 'dendriform';
+import {Dendriform, useDendriform, useInput, useCheckbox, useSync, array, immerable, enableMapSet} from 'dendriform';
 import {Box, Flex} from '../components/Layout';
 import {H2} from '../components/Text';
 import styled from 'styled-components';
@@ -467,6 +467,8 @@ function ES6Classes(): React.ReactElement {
 }
 
 const ES6ClassesCode = `
+import {immerable} from 'dendriform';
+
 class Person {
     firstName = '';
     lastName = '';
@@ -488,6 +490,55 @@ function MyComponent(props) {
         ))}
         {form.render('lastName', form => (
             <label>last name: <input {...useInput(form, 150)} /></label>
+        ))}
+    </div>;
+}
+`;
+
+//
+// es6 maps
+//
+
+enableMapSet();
+
+function ES6Maps(): React.ReactElement {
+
+    const form = useDendriform(() => {
+        const usersById = new Map<number, string>();
+        usersById.set(123, 'Harry');
+        usersById.set(456, 'Larry');
+        return usersById;
+    });
+
+    return <Region>
+        {form.render(123, form => (
+            <label>123: <input {...useInput(form, 150)} /></label>
+        ))}
+        {form.render(456, form => (
+            <label>456: <input {...useInput(form, 150)} /></label>
+        ))}
+    </Region>;
+}
+
+const ES6MapsCode = `
+import {enableMapSet} from 'dendriform';
+enableMapSet();
+
+function MyComponent(props) {
+
+    const form = useDendriform(() => {
+        const usersById = new Map<number, string>();
+        usersById.set(123, 'Harry');
+        usersById.set(456, 'Larry');
+        return usersById;
+    });
+
+    return <div>
+        {form.render(123, form => (
+            <label>123: <input {...useInput(form, 150)} /></label>
+        ))}
+        {form.render(456, form => (
+            <label>456: <input {...useInput(form, 150)} /></label>
         ))}
     </div>;
 }
@@ -1428,6 +1479,12 @@ const DEMOS: DemoObject[] = [
         Demo: ES6Classes,
         code: ES6ClassesCode,
         anchor: 'es6-classes'
+    },
+    {
+        title: 'ES6 maps',
+        Demo: ES6Maps,
+        code: ES6MapsCode,
+        anchor: 'es6-maps'
     },
     {
         title: 'Form inputs',

--- a/packages/dendriform-demo/pages/index.tsx
+++ b/packages/dendriform-demo/pages/index.tsx
@@ -13,7 +13,7 @@ export default function Main(): React.ReactElement {
             </Box>
             <Box maxWidth="20rem">
                 <Logo>dendriform</Logo>
-                <Text as="div" color="subtitle" style={{fontStyle: "italic", lineHeight: '1.3rem'}}>Build feature-rich data-editing React UIs with great performance and not much code.</Text>
+                <Text as="div" color="subtitle" style={{fontStyle: "italic", lineHeight: '1.3rem'}}>Build feature-rich data-editing React UIs with great performance and little code.</Text>
             </Box>
         </Flex>
         <FloatZone>

--- a/packages/dendriform-immer-patch-optimiser/package.json
+++ b/packages/dendriform-immer-patch-optimiser/package.json
@@ -20,7 +20,7 @@
     "prepare": "tsdx build"
   },
   "peerDependencies": {
-    "immer": "7"
+    "immer": "9"
   },
   "husky": {
     "hooks": {
@@ -49,7 +49,7 @@
     "eslint-config-blueflag": "^0.11.1",
     "eslint-plugin-react": "^7.20.6",
     "husky": "^4.2.5",
-    "immer": "7.0.8",
+    "immer": "9.0.1",
     "size-limit": "^4.5.7",
     "ts-loader": "^8.0.3",
     "tsdx": "^0.13.3",

--- a/packages/dendriform-immer-patch-optimiser/test/traverse.test.ts
+++ b/packages/dendriform-immer-patch-optimiser/test/traverse.test.ts
@@ -1,4 +1,4 @@
-import {BASIC, OBJECT, ARRAY, getType, has, get, getIn, set, each, clone} from '../src/index';
+import {BASIC, OBJECT, ARRAY, MAP, getType, has, get, getIn, set, each, clone} from '../src/index';
 
 describe(`getType`, () => {
     test(`should identify basics`, () => {
@@ -17,6 +17,10 @@ describe(`getType`, () => {
 
     test(`should identify array`, () => {
         expect(getType([])).toBe(ARRAY);
+    });
+
+    test(`should identify map`, () => {
+        expect(getType(new Map())).toBe(MAP);
     });
 });
 
@@ -38,6 +42,13 @@ describe(`has`, () => {
         expect(() => has(null, 4)).toThrow(`Cant access property 4 of null`);
         expect(() => has(undefined, 4)).toThrow(`Cant access property 4 of undefined`);
     });
+
+    test(`should work with map`, () => {
+        const map = new Map<number,boolean>([[0,true],[2,false]]);
+        expect(has(map, 0)).toBe(true);
+        expect(has(map, 1)).toBe(false);
+        expect(has(map, 2)).toBe(true);
+    });
 });
 
 describe(`get`, () => {
@@ -55,6 +66,16 @@ describe(`get`, () => {
 
     test(`should work with array and miss`, () => {
         expect(get(['a','b'], 4)).toBe(undefined);
+    });
+
+    test(`should work with map`, () => {
+        const map = new Map<number,boolean>([[0,true],[2,false]]);
+        expect(get(map, 2)).toBe(false);
+    });
+
+    test(`should work with map and miss`, () => {
+        const map = new Map<number,boolean>([[0,true],[2,false]]);
+        expect(get(map, 1)).toBe(undefined);
     });
 
     test(`should error on basic types`, () => {
@@ -100,6 +121,12 @@ describe(`set`, () => {
         expect(arr).toEqual([1,20,3]);
     });
 
+    test(`should work with map`, () => {
+        const map = new Map<number,boolean>([[0,true],[2,false]]);
+        set(map, 2, true);
+        expect(map.get(2)).toBe(true);
+    });
+
     test(`should error on basic types`, () => {
         expect(() => set(100, 4, 4)).toThrow(`Cant access property 4 of 100`);
         expect(() => set("str", 4, 4)).toThrow(`Cant access property 4 of str`);
@@ -138,6 +165,18 @@ describe(`each`, () => {
         expect(callback.mock.calls[2][1]).toBe(2);
     });
 
+    test(`should work with map`, () => {
+        const callback = jest.fn();
+        const map = new Map([['foo', 1], ['bar', 2]]);
+
+        each(map, callback);
+
+        expect(callback).toHaveBeenCalledTimes(2);
+        expect(callback.mock.calls[0][0]).toBe(1);
+        expect(callback.mock.calls[0][1]).toBe('foo');
+        expect(callback.mock.calls[1][0]).toBe(2);
+    });
+
     test(`should error on basic types`, () => {
         const callback = jest.fn();
 
@@ -169,5 +208,14 @@ describe(`clone`, () => {
 
         expect(cloned).not.toBe(arr);
         expect(cloned).toEqual(arr);
+    });
+
+    test(`should work with map`, () => {
+        const map = new Map([['foo', 1], ['bar', 2]]);
+        const cloned = clone(map);
+
+        expect(cloned).not.toBe(map);
+        expect(cloned.get('foo')).toBe(1);
+        expect(cloned.get('bar')).toBe(2);
     });
 });

--- a/packages/dendriform/.size-limit.js
+++ b/packages/dendriform/.size-limit.js
@@ -2,7 +2,7 @@ module.exports = [
     {
         name: 'everything combined',
         path: "dist/dendriform.esm.js",
-        limit: "8.3 KB",
+        limit: "8.4 KB",
         ignore: ['react', 'react-dom']
     },
     {

--- a/packages/dendriform/.size-limit.js
+++ b/packages/dendriform/.size-limit.js
@@ -16,7 +16,7 @@ module.exports = [
         name: 'Dendriform',
         path: "dist/dendriform.esm.js",
         import: "{ Dendriform }",
-        limit: "7.5 KB",
+        limit: "7.6 KB",
         ignore: ['react', 'react-dom']
     },
     {

--- a/packages/dendriform/README.md
+++ b/packages/dendriform/README.md
@@ -466,10 +466,8 @@ form.branch(456).set('Janet');
 
 To modify a `Map`s value, support must be explicitly enabled by calling `enableMapSet()` [as immer's documentation describes(https://immerjs.github.io/immer/map-set).
 
-You should import `enableMapSet` from `dendriform` so you are guaranteed to enable Maps on the version of immer that dendriform uses.
-
 ```js
-import {enableMapSet} from 'dendriform';
+import {enableMapSet} from 'immer';
 
 enableMapSet();
 

--- a/packages/dendriform/README.md
+++ b/packages/dendriform/README.md
@@ -87,7 +87,8 @@ npm install --save dendriform
 - [Rendering](#rendering)
 - [Rendering arrays](#rendering-arrays)
 - [Setting data](#setting-data)
-- [ES6 classes](#esr-classes)
+- [ES6 classes](#es6-classes)
+- [ES6 maps](#es6-maps)
 - [Form inputs](#form-inputs)
 - [Subscribing to changes](#subscribing-to-changes)
 - [Array operations](#array-operations)
@@ -130,7 +131,7 @@ function MyComponent(props) {
 }
 ```
 
-The value can be of any type, however only plain objects, arrays and [ES6 classes](#es6-classes) will be able to use [branching](#branching) to access and modify child values.
+The value can be of any type, however only plain objects, arrays, [ES6 classes](#es6-classes) and [ES6 maps](#es6-maps) will be able to use [branching](#branching) to access and modify child values.
 
 ### Values
 
@@ -439,6 +440,48 @@ const form = new Dendriform(person);
 form.branch('firstName').set('Janet');
 ```
 
+[Demo](http://dendriform.xyz#es6-classes)
+
+### ES6 maps
+
+ES6 maps can be stored in a form and its properties can be accessed using branch methods.
+
+```js
+const usersById = new Map();
+usersById.set(123, 'Harry');
+usersById.set(456, 'Larry');
+
+const form = new Dendriform(usersById);
+
+// form.branch(123).value will be 'Harry'
+```
+
+But by default you will not be able to modify this value.
+
+```js
+const form = new Dendriform(usersById);
+form.branch(456).set('Janet');
+// ^ throws an error
+```
+
+To modify a `Map`s value, support must be explicitly enabled by calling `enableMapSet()` [as immer's documentation describes(https://immerjs.github.io/immer/map-set).
+
+You should import `enableMapSet` from `dendriform` so you are guaranteed to enable Maps on the version of immer that dendriform uses.
+
+```js
+import {enableMapSet} from 'dendriform';
+
+enableMapSet();
+
+const usersById = new Map();
+usersById.set(123, 'Harry');
+usersById.set(456, 'Larry');
+
+const form = new Dendriform(usersById);
+form.branch(456).set('Janet');
+```
+
+[Demo](http://dendriform.xyz#es6-maps)
 
 ### Form inputs
 

--- a/packages/dendriform/README.md
+++ b/packages/dendriform/README.md
@@ -7,7 +7,7 @@
 
 
 
-Build feature-rich data-editing React UIs with great performance and not much code.
+Build feature-rich data-editing React UIs with great performance and little code.
 
 **[See the demos](http://dendriform.xyz)**
 
@@ -87,6 +87,7 @@ npm install --save dendriform
 - [Rendering](#rendering)
 - [Rendering arrays](#rendering-arrays)
 - [Setting data](#setting-data)
+- [ES6 classes](#esr-classes)
 - [Form inputs](#form-inputs)
 - [Subscribing to changes](#subscribing-to-changes)
 - [Array operations](#array-operations)
@@ -129,7 +130,7 @@ function MyComponent(props) {
 }
 ```
 
-The value can be of any type, however only plain objects and arrays will be able to use [branching](#branching) to access and modify child values.
+The value can be of any type, however only plain objects, arrays and [ES6 classes](#es6-classes) will be able to use [branching](#branching) to access and modify child values.
 
 ### Values
 
@@ -390,6 +391,55 @@ form.done();
 // form.value will update to become 3
 ```
 
+### ES6 classes
+
+ES6 classes can be stored in a form and its properties can be accessed using branch methods.
+
+```js
+class Person {
+    firstName = '';
+    lastName = '';
+}
+
+const person = new Person();
+person.firstName = 'Billy';
+person.lastName = 'Thump';
+
+const form = new Dendriform(person);
+
+// form.branch('firstName').value will be 'Billy'
+```
+
+But by default you will not be able to modify this value.
+
+```js
+const form = new Dendriform(person);
+form.branch('firstName').set('Janet');
+// ^ throws an error
+```
+
+To modify a class property, your class must have the `immerable` property on it [as immer's documentation describes(https://immerjs.github.io/immer/complex-objects).
+
+You should import `immerable` from `dendriform` so you are guaranteed to get the immerable symbol from the version of immer that dendriform uses.
+
+```js
+import {immerable} from 'dendriform';
+
+class Person {
+    firstName = '';
+    lastName = '';
+    [immerable] = true; // makes the class immerable
+}
+
+const person = new Person();
+person.firstName = 'Billy';
+person.lastName = 'Thump';
+
+const form = new Dendriform(person);
+form.branch('firstName').set('Janet');
+```
+
+
 ### Form inputs
 
 You can easily bind parts of your data to form inputs using `useInput()` and `useCheckbox()`. The props they return can be spread onto form elements. A debounce value (milliseconds) can also be provided to `useInput()` to prevent too many updates happening in a short space of time.
@@ -593,7 +643,7 @@ function MyComponent(props) {
 
 Dendriform can keep track of the history of changes and supports undo and redo. Activate this by specifying the maximum number of undos you would like to allow in the options object when creating a form.
 
-History items consist of immer patches that have been optimised, so they take up very little memory in comparison to full state snapshots.
+History items consist of [immer patches](https://immerjs.github.io/immer/patches) that have been optimised, so they take up very little memory in comparison to full state snapshots.
 
 ```js
 const form = new Dendriform({name: 'Bill'}, {history: 50});

--- a/packages/dendriform/package.json
+++ b/packages/dendriform/package.json
@@ -2,7 +2,7 @@
   "version": "2.0.0-alpha.3",
   "license": "MIT",
   "main": "dist/index.js",
-  "description": "Build feature-rich data-editing React UIs with great performance and not much code.",
+  "description": "Build feature-rich data-editing React UIs with great performance and little code.",
   "typings": "dist/index.d.ts",
   "files": [
     "dist",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "dendriform-immer-patch-optimiser": "^1.0.0-alpha.1",
-    "immer": "7.0.8",
+    "immer": "9.0.1",
     "shallow-equal": "1.2.1"
   },
   "peerDependencies": {

--- a/packages/dendriform/src/Dendriform.tsx
+++ b/packages/dendriform/src/Dendriform.tsx
@@ -456,6 +456,12 @@ type Renderer<D> = (form: D) => React.ReactElement;
 
 type ChildToProduce<V> = (key: PropertyKey) => ToProduce<V>;
 
+type KeyMap<M extends Map<unknown, unknown>> = M extends Map<infer K, unknown> ? K : never;
+type ValMap<A> = A extends Map<unknown, infer V> ? V : never;
+
+type Key<V> = V extends Map<unknown, unknown> ? KeyMap<V> : keyof V;
+type Val<V,K> = V extends Map<unknown, unknown> ? ValMap<V> : K extends keyof V ? V[K] : never;
+
 export class Dendriform<V,C=V> {
 
     // dev notes:
@@ -587,12 +593,12 @@ export class Dendriform<V,C=V> {
     // branching
     //
 
-    branch<K1 extends keyof V, K2 extends keyof V[K1], K3 extends keyof V[K1][K2], K4 extends keyof V[K1][K2][K3]>(path: [K1, K2, K3, K4]): Dendriform<V[K1][K2][K3][K4],C>;
-    branch<K1 extends keyof V, K2 extends keyof V[K1], K3 extends keyof V[K1][K2]>(path: [K1, K2, K3]): Dendriform<V[K1][K2][K3],C>;
-    branch<K1 extends keyof V, K2 extends keyof V[K1]>(path: [K1, K2]): Dendriform<V[K1][K2],C>;
-    branch<K1 extends keyof V>(path: [K1]): Dendriform<V[K1],C>;
+    branch<K1 extends Key<V>, K2 extends keyof Val<V,K1>, K3 extends keyof Val<Val<V,K1>,K2>, K4 extends keyof Val<Val<Val<V,K1>,K2>,K3>>(path: [K1, K2, K3, K4]): Dendriform<Val<Val<Val<V,K1>,K2>,K3>[K4],C>;
+    branch<K1 extends Key<V>, K2 extends keyof Val<V,K1>, K3 extends keyof Val<Val<V,K1>,K2>>(path: [K1, K2, K3]): Dendriform<Val<Val<Val<V,K1>,K2>,K3>,C>;
+    branch<K1 extends Key<V>, K2 extends keyof Val<V,K1>>(path: [K1, K2]): Dendriform<Val<Val<V,K1>,K2>,C>;
+    branch<K1 extends Key<V>>(path: [K1]): Dendriform<Val<V,K1>,C>;
     branch(path?: []): Dendriform<V,C>;
-    branch<K1 extends keyof V>(key: K1): Dendriform<V[K1],C>;
+    branch<K1 extends Key<V>>(key: K1): Dendriform<Val<V,K1>,C>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
     branch(pathOrKey: any): any {
         const appendPath = ([] as Path).concat(pathOrKey ?? []);
@@ -600,11 +606,11 @@ export class Dendriform<V,C=V> {
         return this.core.getFormAt(basePath.concat(appendPath));
     }
 
-    branchAll<K1 extends keyof V, K2 extends keyof V[K1], K3 extends keyof V[K1][K2], K4 extends keyof V[K1][K2][K3], W extends V[K1][K2][K3][K4] & unknown[]>(path: [K1, K2, K3, K4]): Dendriform<W[0],C>[];
-    branchAll<K1 extends keyof V, K2 extends keyof V[K1], K3 extends keyof V[K1][K2], W extends V[K1][K2][K3] & unknown[]>(path: [K1, K2, K3]): Dendriform<W[0],C>[];
-    branchAll<K1 extends keyof V, K2 extends keyof V[K1], W extends V[K1][K2] & unknown[]>(path: [K1, K2]): Dendriform<W[0],C>[];
-    branchAll<K1 extends keyof V, W extends V[K1] & unknown[]>(path: [K1]): Dendriform<W[0],C>[];
-    branchAll<K1 extends keyof V, W extends V[K1] & unknown[]>(key: K1): Dendriform<W[0],C>[];
+    branchAll<K1 extends Key<V>, K2 extends keyof Val<V,K1>, K3 extends keyof Val<Val<V,K1>,K2>, K4 extends keyof Val<Val<Val<V,K1>,K2>,K3>, W extends Val<Val<Val<V,K1>,K2>,K3>[K4] & unknown[]>(path: [K1, K2, K3, K4]): Dendriform<W[0],C>[];
+    branchAll<K1 extends Key<V>, K2 extends keyof Val<V,K1>, K3 extends keyof Val<Val<V,K1>,K2>, W extends Val<Val<Val<V,K1>,K2>,K3> & unknown[]>(path: [K1, K2, K3]): Dendriform<W[0],C>[];
+    branchAll<K1 extends Key<V>, K2 extends keyof Val<V,K1>, W extends Val<Val<V,K1>,K2> & unknown[]>(path: [K1, K2]): Dendriform<W[0],C>[];
+    branchAll<K1 extends Key<V>, W extends Val<V,K1> & unknown[]>(path: [K1]): Dendriform<W[0],C>[];
+    branchAll<K1 extends Key<V>, W extends Val<V,K1> & unknown[]>(key: K1): Dendriform<W[0],C>[];
     branchAll<W extends V & unknown[]>(path?: []): Dendriform<W[0],C>[];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
     branchAll(pathOrKey: any): any {
@@ -616,12 +622,12 @@ export class Dendriform<V,C=V> {
         return array.map((_element, index) => got.branch(index as any));
     }
 
-    render<K1 extends keyof V, K2 extends keyof V[K1], K3 extends keyof V[K1][K2], K4 extends keyof V[K1][K2][K3]>(path: [K1, K2, K3, K4], renderer: Renderer<Dendriform<V[K1][K2][K3][K4],C>>, deps?: unknown[]): React.ReactElement;
-    render<K1 extends keyof V, K2 extends keyof V[K1], K3 extends keyof V[K1][K2]>(path: [K1, K2, K3], renderer: Renderer<Dendriform<V[K1][K2][K3],C>>, deps?: unknown[]): React.ReactElement;
-    render<K1 extends keyof V, K2 extends keyof V[K1]>(path: [K1, K2], renderer: Renderer<Dendriform<V[K1][K2],C>>, deps?: unknown[]): React.ReactElement;
-    render<K1 extends keyof V>(path: [K1], renderer: Renderer<Dendriform<V[K1],C>>, deps?: unknown[]): React.ReactElement;
+    render<K1 extends Key<V>, K2 extends keyof Val<V,K1>, K3 extends keyof Val<Val<V,K1>,K2>, K4 extends keyof Val<Val<Val<V,K1>,K2>,K3>>(path: [K1, K2, K3, K4], renderer: Renderer<Dendriform<Val<Val<Val<V,K1>,K2>,K3>[K4],C>>, deps?: unknown[]): React.ReactElement;
+    render<K1 extends Key<V>, K2 extends keyof Val<V,K1>, K3 extends keyof Val<Val<V,K1>,K2>>(path: [K1, K2, K3], renderer: Renderer<Dendriform<Val<Val<Val<V,K1>,K2>,K3>,C>>, deps?: unknown[]): React.ReactElement;
+    render<K1 extends Key<V>, K2 extends keyof Val<V,K1>>(path: [K1, K2], renderer: Renderer<Dendriform<Val<Val<V,K1>,K2>,C>>, deps?: unknown[]): React.ReactElement;
+    render<K1 extends Key<V>>(path: [K1], renderer: Renderer<Dendriform<Val<V,K1>,C>>, deps?: unknown[]): React.ReactElement;
     render(path: [], renderer: Renderer<Dendriform<V,C>>, deps?: unknown[]): React.ReactElement;
-    render<K1 extends keyof V>(key: K1, renderer: Renderer<Dendriform<V[K1],C>>, deps?: unknown[]): React.ReactElement;
+    render<K1 extends Key<V>>(key: K1, renderer: Renderer<Dendriform<Val<V,K1>,C>>, deps?: unknown[]): React.ReactElement;
     render(renderer: Renderer<Dendriform<V,C>>, deps?: unknown[], notNeeded?: unknown): React.ReactElement;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any,  @typescript-eslint/explicit-module-boundary-types
     render(a: any, b: any, c: any): React.ReactElement {
@@ -632,12 +638,12 @@ export class Dendriform<V,C=V> {
         return <Branch renderer={() => renderer(form)} deps={deps} />;
     }
 
-    renderAll<K1 extends keyof V, K2 extends keyof V[K1], K3 extends keyof V[K1][K2], K4 extends keyof V[K1][K2][K3], W extends V[K1][K2][K3][K4] & unknown[]>(path: [K1, K2, K3, K4], renderer: Renderer<Dendriform<W[0],C>>, deps?: unknown[]): React.ReactElement;
-    renderAll<K1 extends keyof V, K2 extends keyof V[K1], K3 extends keyof V[K1][K2], W extends V[K1][K2][K3] & unknown[]>(path: [K1, K2, K3], renderer: Renderer<Dendriform<W[0],C>>, deps?: unknown[]): React.ReactElement;
-    renderAll<K1 extends keyof V, K2 extends keyof V[K1], W extends V[K1][K2] & unknown[]>(path: [K1, K2], renderer: Renderer<Dendriform<W[0],C>>, deps?: unknown[]): React.ReactElement;
-    renderAll<K1 extends keyof V, W extends V[K1] & unknown[]>(path: [K1], renderer: Renderer<Dendriform<W[0],C>>, deps?: unknown[]): React.ReactElement;
+    renderAll<K1 extends Key<V>, K2 extends keyof Val<V,K1>, K3 extends keyof Val<Val<V,K1>,K2>, K4 extends keyof Val<Val<Val<V,K1>,K2>,K3>, W extends Val<Val<Val<V,K1>,K2>,K3>[K4] & unknown[]>(path: [K1, K2, K3, K4], renderer: Renderer<Dendriform<W[0],C>>, deps?: unknown[]): React.ReactElement;
+    renderAll<K1 extends Key<V>, K2 extends keyof Val<V,K1>, K3 extends keyof Val<Val<V,K1>,K2>, W extends Val<Val<Val<V,K1>,K2>,K3> & unknown[]>(path: [K1, K2, K3], renderer: Renderer<Dendriform<W[0],C>>, deps?: unknown[]): React.ReactElement;
+    renderAll<K1 extends Key<V>, K2 extends keyof Val<V,K1>, W extends Val<Val<V,K1>,K2> & unknown[]>(path: [K1, K2], renderer: Renderer<Dendriform<W[0],C>>, deps?: unknown[]): React.ReactElement;
+    renderAll<K1 extends Key<V>, W extends Val<V,K1> & unknown[]>(path: [K1], renderer: Renderer<Dendriform<W[0],C>>, deps?: unknown[]): React.ReactElement;
     renderAll<W extends V & unknown[]>(path: [], renderer: Renderer<Dendriform<W[0],C>>, deps?: unknown[]): React.ReactElement;
-    renderAll<K1 extends keyof V, W extends V[K1] & unknown[]>(key: K1, renderer: Renderer<Dendriform<W[0],C>>, deps?: unknown[]): React.ReactElement;
+    renderAll<K1 extends Key<V>, W extends Val<V,K1> & unknown[]>(key: K1, renderer: Renderer<Dendriform<W[0],C>>, deps?: unknown[]): React.ReactElement;
     renderAll<W extends V & unknown[]>(renderer: Renderer<Dendriform<W[0],C>>, deps?: unknown[], notNeeded?: unknown): React.ReactElement;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
     renderAll(a: any, b: any, c: any): React.ReactElement {

--- a/packages/dendriform/src/Nodes.ts
+++ b/packages/dendriform/src/Nodes.ts
@@ -1,4 +1,4 @@
-import {BASIC, OBJECT, ARRAY, getType, has, get, set, each, clone, applyPatches} from 'dendriform-immer-patch-optimiser';
+import {BASIC, OBJECT, ARRAY, MAP, getType, has, get, set, each, clone, applyPatches} from 'dendriform-immer-patch-optimiser';
 import type {Path, DendriformPatch} from 'dendriform-immer-patch-optimiser';
 import {produceWithPatches, setAutoFreeze} from 'immer';
 
@@ -20,6 +20,13 @@ export type NodeArray = {
     parentId: number;
 };
 
+export type NodeMap = {
+    type: typeof MAP;
+    child?: Map<string|number,number>;
+    id: number;
+    parentId: number;
+};
+
 export type NodeBasic = {
     type: typeof BASIC;
     child: undefined;
@@ -27,7 +34,7 @@ export type NodeBasic = {
     parentId: number;
 };
 
-export type NodeAny = NodeObject|NodeArray|NodeBasic;
+export type NodeAny = NodeObject|NodeArray|NodeBasic|NodeMap;
 
 export type Nodes = {[id: string]: NodeAny};
 
@@ -63,7 +70,12 @@ export const _prepChild = <P>(
 
     if(parentNode.type === BASIC || parentNode.child) return;
 
-    const child: number[]|{[key: string]: number} = parentNode.type === ARRAY ? [] : {};
+    const child: number[]|{[key: string]: number}|Map<string|number,number> = parentNode.type === MAP
+        ? new Map()
+        : parentNode.type === ARRAY
+            ? []
+            : {};
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     each(parentValueRef, (value, key: any) => {
         const childNode = newNodeCreator(value, parentNode.id);

--- a/packages/dendriform/src/Nodes.ts
+++ b/packages/dendriform/src/Nodes.ts
@@ -167,7 +167,7 @@ export const produceNodePatches = (
     newNodeCreator: NewNodeCreator,
     baseValue: unknown,
     valuePatches: DendriformPatch[]
-): [Nodes, DendriformPatch[], DendriformPatch[]] => {
+): readonly [Nodes, DendriformPatch[], DendriformPatch[]] => {
 
     const result = produceWithPatches(nodes, draft => {
 
@@ -233,5 +233,5 @@ export const produceNodePatches = (
 
     (result[1] as DendriformPatch[]).forEach(patch => patch.namespace = 'nodes');
     (result[2] as DendriformPatch[]).forEach(patch => patch.namespace = 'nodes');
-    return result;
+    return result as readonly [Nodes, DendriformPatch[], DendriformPatch[]];
 };

--- a/packages/dendriform/src/index.ts
+++ b/packages/dendriform/src/index.ts
@@ -6,4 +6,4 @@ export * from './array';
 export * from './useInput';
 export * from './useCheckbox';
 export * from './sync';
-export {immerable, enableMapSet} from 'immer';
+export {immerable} from 'immer';

--- a/packages/dendriform/src/index.ts
+++ b/packages/dendriform/src/index.ts
@@ -6,4 +6,4 @@ export * from './array';
 export * from './useInput';
 export * from './useCheckbox';
 export * from './sync';
-export {immerable} from 'immer';
+export {immerable, enableMapSet} from 'immer';

--- a/packages/dendriform/src/index.ts
+++ b/packages/dendriform/src/index.ts
@@ -6,3 +6,4 @@ export * from './array';
 export * from './useInput';
 export * from './useCheckbox';
 export * from './sync';
+export {immerable} from 'immer';

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -1,9 +1,10 @@
-import {useDendriform, Dendriform, noChange, sync, useSync, immerable, enableMapSet} from '../src/index';
+import {useDendriform, Dendriform, noChange, sync, useSync, immerable} from '../src/index';
 import {renderHook, act} from '@testing-library/react-hooks';
 
 import React from 'react';
 import Enzyme, {mount} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import {enableMapSet} from 'immer';
 
 Enzyme.configure({
     adapter: new Adapter()

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -1,4 +1,4 @@
-import {useDendriform, Dendriform, noChange, sync, useSync} from '../src/index';
+import {useDendriform, Dendriform, noChange, sync, useSync, immerable} from '../src/index';
 import {renderHook, act} from '@testing-library/react-hooks';
 
 import React from 'react';
@@ -668,6 +668,50 @@ describe(`Dendriform`, () => {
         });
 
         // TODO what about misses?
+    });
+
+    describe(`es6 values`, () => {
+
+        describe(`es6 class`, () => {
+
+            test(`should allow branching of plain ES6 class, but not setting`, () => {
+                expect.assertions(3);
+
+                class MyClass {
+                    hello = "hi";
+                }
+
+                const instance = new MyClass();
+
+                const form = new Dendriform(instance);
+                expect(form.value).toBe(instance);
+                expect(form.branch('hello').value).toBe("hi");
+
+                expect(() => form.branch('hello').set('bye')).toThrow('produce can only be called on things that are draftable');
+            });
+
+            test(`should allow branching and setting if class is immerable`, () => {
+
+                class MyClass {
+                    hello = "hi";
+                    [immerable] = true;
+                }
+
+                const instance = new MyClass();
+
+                const form = new Dendriform(instance);
+                expect(form.value).toBe(instance);
+                expect(form.branch('hello').value).toBe("hi");
+
+                form.branch('hello').set('bye');
+                expect(form.value).toEqual({
+                    hello: 'bye',
+                    [immerable]: true
+                });
+            });
+
+        });
+
     });
 
     describe(`.render()`, () => {

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -1,4 +1,4 @@
-import {useDendriform, Dendriform, noChange, sync, useSync, immerable} from '../src/index';
+import {useDendriform, Dendriform, noChange, sync, useSync, immerable, enableMapSet} from '../src/index';
 import {renderHook, act} from '@testing-library/react-hooks';
 
 import React from 'react';
@@ -8,6 +8,8 @@ import Adapter from 'enzyme-adapter-react-16';
 Enzyme.configure({
     adapter: new Adapter()
 });
+
+enableMapSet();
 
 type MyComponentProps<V> = {
     foo: number;
@@ -708,6 +710,38 @@ describe(`Dendriform`, () => {
                     hello: 'bye',
                     [immerable]: true
                 });
+            });
+
+        });
+
+        describe(`es6 Map`, () => {
+
+            test(`should allow branching and setting of ES6 Map`, () => {
+
+                const form = new Dendriform(new Map<string,number>([
+                    ['one', 1],
+                    ['two', 2]
+                ]));
+
+                expect(form.branch('one').value).toBe(1);
+
+                form.branch('one').set(3);
+                expect(form.value.get('one')).toBe(3);
+                expect(form.value.get('two')).toBe(2);
+            });
+
+            test(`should allow branching and setting of ES6 Map with numeric keys`, () => {
+
+                const form = new Dendriform(new Map<number,string>([
+                    [1, 'one'],
+                    [2, 'two']
+                ]));
+
+                expect(form.branch(1).value).toBe('one');
+
+                form.branch(1).set('one!');
+                expect(form.value.get(1)).toBe('one!');
+                expect(form.value.get(2)).toBe('two');
             });
 
         });

--- a/packages/dendriform/test/Nodes.test.ts
+++ b/packages/dendriform/test/Nodes.test.ts
@@ -1,6 +1,6 @@
 import {newNode, addNode, getNode, getPath, getNodeByPath, updateNode, removeNode, produceNodePatches} from '../src/index';
 import type {Nodes, NodeAny, NewNodeCreator} from '../src/index';
-import {BASIC, OBJECT, ARRAY, applyPatches} from 'dendriform-immer-patch-optimiser';
+import {BASIC, OBJECT, ARRAY, MAP, applyPatches} from 'dendriform-immer-patch-optimiser';
 
 const createNodesFrom = (value: unknown): [Nodes, NewNodeCreator] => {
     const nodes = {};
@@ -77,6 +77,24 @@ describe(`Nodes`, () => {
 
             expect(newNode(countRef)(arr, -1)).toEqual({
                 type: ARRAY,
+                child: undefined,
+                parentId: -1,
+                id: 0
+            });
+        });
+
+        test(`should accept maps`, () => {
+            const countRef = {
+                current: 0
+            };
+
+            const map = new Map<number,string>([
+                [1, 'one'],
+                [2, 'two']
+            ]);
+
+            expect(newNode(countRef)(map, -1)).toEqual({
+                type: MAP,
                 child: undefined,
                 parentId: -1,
                 id: 0

--- a/yarn.lock
+++ b/yarn.lock
@@ -6492,9 +6492,9 @@ ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
 
-immer@7.0.8:
-  version "7.0.8"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.8.tgz#41dcbc5669a76500d017bef3ad0d03ce0a1d7c1e"
+immer@9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.1.tgz#1116368e051f9a0fd188c5136b6efb74ed69c57f"
 
 import-fresh@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- Adds support for ES6 classes #14 
- Adds support for ES6 maps #24 
  - Sets will not be considered until further notice, as their api differs to greatly from everything else, and its unclear whether we even need them yet. For now people can use ES6 Maps with arbitrary keys.
- Upgrade immer to 9 (addresses half of #23 )