### PR TITLE
Feature/remove node mutations

### DIFF
--- a/packages/dendriform-demo/components/Demos.tsx
+++ b/packages/dendriform-demo/components/Demos.tsx
@@ -1441,7 +1441,6 @@ const BLANK_PERSON = {
 };
 
 type ValidationMap = {
-    all: string[];
     [id: string]: string;
 };
 
@@ -1451,25 +1450,29 @@ function Validation(): React.ReactElement {
     const addNew = useCallback(() => form.set(array.push(BLANK_PERSON)), []);
 
     // validation
-    const validationForm = useDendriform<ValidationMap>({all: []});
+    const errorMapForm = useDendriform<ValidationMap>({});
+    const errorListForm = useDendriform<string[]>([]);
+
     form.useDerive(() => {
-        const validationMap: ValidationMap = {all: []};
+        const validationMap: ValidationMap = {};
+        const errorList: string[] = [];
 
         form.branchAll().forEach(form => {
             const nameForm = form.branch('name');
             if(nameForm.value === '') {
                 validationMap[nameForm.id] = 'Name must not be blank';
-                validationMap.all.push(`Name #${form.index + 1} must not be blank`);
+                errorList.push(`Name #${form.index + 1} must not be blank`);
             }
 
             const ageForm = form.branch('age');
             if(isNaN(parseFloat(ageForm.value))) {
                 validationMap[ageForm.id] = 'Age must be numeric';
-                validationMap.all.push(`Age #${form.index + 1} must be numeric`);
+                errorList.push(`Age #${form.index + 1} must be numeric`);
             }
         });
 
-        validationForm.set(validationMap);
+        errorMapForm.set(validationMap);
+        errorListForm.set(errorList);
     });
 
     return <Region>
@@ -1483,13 +1486,13 @@ function Validation(): React.ReactElement {
                 {form.render('name', form => {
                     return <Region>
                         <label>name: <input {...useInput(form, 150)} /></label>
-                        <Text fontSize="small">{validationForm.branch(form.id).useValue()}</Text>
+                        <Text fontSize="small">{errorMapForm.branch(form.id).useValue()}</Text>
                     </Region>;
                 })}
                 {form.render('age', form => (
                     <Region>
                         <label>age: {' '}<input {...useInput(form, 150)} /></label>
-                        <Text fontSize="small">{validationForm.branch(form.id).useValue()}</Text>
+                        <Text fontSize="small">{errorMapForm.branch(form.id).useValue()}</Text>
                     </Region>
                 ))}
 
@@ -1500,7 +1503,7 @@ function Validation(): React.ReactElement {
         })}
         <button onClick={addNew}>add new</button>
 
-        {validationForm.render('all', form => {
+        {errorListForm.render(form => {
             const errors = form.useValue();
             return <Region>
                 Errors:
@@ -1528,25 +1531,29 @@ function MyComponent(props) {
     const addNew = useCallback(() => form.set(array.push(BLANK_PERSON)), []);
 
     // validation
-    const validationForm = useDendriform({all: []});
+    const errorMapForm = useDendriform<ValidationMap>({});
+    const errorListForm = useDendriform<string[]>([]);
+
     form.useDerive(() => {
-        const validationMap = {all: []};
+        const validationMap: ValidationMap = {};
+        const errorList: string[] = [];
 
         form.branchAll().forEach(form => {
             const nameForm = form.branch('name');
             if(nameForm.value === '') {
                 validationMap[nameForm.id] = 'Name must not be blank';
-                validationMap.all.push(\`Name #\${form.index + 1} must not be blank\`);
+                errorList.push(\`Name #\${form.index + 1} must not be blank\`);
             }
 
             const ageForm = form.branch('age');
             if(isNaN(parseFloat(ageForm.value))) {
                 validationMap[ageForm.id] = 'Age must be numeric';
-                validationMap.all.push(\`Age #\${form.index + 1} must be numeric\`);
+                errorList.push(\`Age #\${form.index + 1} must be numeric\`);
             }
         });
 
-        validationForm.set(validationMap);
+        errorMapForm.set(validationMap);
+        errorListForm.set(errorList);
     });
 
     return <>
@@ -1560,13 +1567,13 @@ function MyComponent(props) {
                 {form.render('name', form => {
                     return <>
                         <label>name: <input {...useInput(form, 150)} /></label>
-                        <Text fontSize="small">{validationForm.branch(form.id).useValue()}</Text>
+                        <Text fontSize="small">{errorMapForm.branch(form.id).useValue()}</Text>
                     </>;
                 })}
                 {form.render('age', form => (
                     <>
                         <label>age: {' '}<input {...useInput(form, 150)} /></label>
-                        <Text fontSize="small">{validationForm.branch(form.id).useValue()}</Text>
+                        <Text fontSize="small">{errorMapForm.branch(form.id).useValue()}</Text>
                     </>
                 ))}
 
@@ -1577,7 +1584,7 @@ function MyComponent(props) {
         })}
         <button onClick={addNew}>add new</button>
 
-        {validationForm.render('all', form => {
+        {errorListForm.render(form => {
             const errors = form.useValue();
             return <>
                 Errors:

--- a/packages/dendriform-demo/components/Demos.tsx
+++ b/packages/dendriform-demo/components/Demos.tsx
@@ -702,7 +702,7 @@ function MyComponent(props) {
 // array
 //
 
-const offsetElement = (form: Dendriform<string, {colours: string[]}>, offset: number): void => {
+const offsetElement = <T,>(form: Dendriform<T,unknown>, offset: number): void => {
     return form.setParent(index => array.move(index as number, index as number + offset));
 };
 
@@ -812,6 +812,10 @@ function ArrayIndexes(): React.ReactElement {
 }
 
 const ArrayIndexesCode = `
+const offsetElement = (form, offset) => {
+    return form.setParent(index => array.move(index, index + offset));
+};
+
 function MyComponent(props) {
 
     const form = useDendriform({
@@ -1194,6 +1198,7 @@ function SyncDerive(): React.ReactElement {
     }), {history: 100});
 
     useSync(namesForm, addressForm, names => {
+        console.log(`Deriving occupants for ${JSON.stringify(names)}`);
         addressForm.branch('occupants').set(names.length);
     });
 
@@ -1234,26 +1239,49 @@ function SyncDerive(): React.ReactElement {
 
 const SyncDeriveCode = `
 function MyComponent(props) {
-    const nameForm = useDendriform(() => ({name: 'Bill'}), {history: 100});
-    const addressForm = useDendriform(() => ({street: 'Cool St'}), {history: 100});
 
-    useSync(nameForm, addressForm);
+    const namesForm = useDendriform(() => ['Bill', 'Ben', 'Bob'], {history: 100});
+
+    const addressForm = useDendriform(() => ({
+        street: 'Cool St',
+        occupants: 0
+    }), {history: 100});
+
+    useSync(namesForm, addressForm, names => {
+        addressForm.branch('occupants').set(names.length);
+    });
+
+    const addName = useCallback(() => {
+        namesForm.set(draft => {
+            draft.push('Name ' + draft.length);
+        });
+    }, []);
 
     return <div>
-        {nameForm.render('name', form => (
-            <label>name: <input {...useInput(form, 150)} /></label>
-        ))}
+        <fieldset>
+            <legend>names</legend>
+            <ul>
+                {namesForm.renderAll(form => <Region of="li">
+                    <label><input {...useInput(form, 150)} /></label>
+                </Region>)}
+            </ul>
+            <button onClick={addName}>Add name</button>
+        </fieldset>
 
         {addressForm.render('street', form => (
             <label>street: <input {...useInput(form, 150)} /></label>
         ))}
 
-        {nameForm.render(form => {
+        {addressForm.render('occupants', form => (
+            <code>occupants: {form.useValue()}</code>
+        ))}
+
+        {namesForm.render(form => {
             const {canUndo, canRedo} = form.useHistory();
-            return <div>
+            return <>
                 <button onClick={form.undo} disabled={!canUndo}>Undo</button>
                 <button onClick={form.redo} disabled={!canRedo}>Redo</button>
-            </div>;
+            </>;
         })}
     </div>;
 }
@@ -1399,6 +1427,106 @@ function DragAndDropList(props) {
 `;
 
 //
+// validation
+//
+
+type ValidationPerson = {
+    name: string;
+    age: string;
+};
+
+const BLANK_PERSON = {
+    name: '',
+    age: ''
+};
+
+type ValidationMap = {
+    [id: string]: string;
+};
+
+function Validation(): React.ReactElement {
+
+    const form = useDendriform<ValidationPerson[]>([BLANK_PERSON]);
+    const validationForm = useDendriform<ValidationMap>({});
+
+    form.useDerive(() => {
+        const validationMap: ValidationMap = {};
+
+        form.branchAll().forEach(form => {
+            const nameForm = form.branch('name');
+            const name = nameForm.value;
+            validationMap[nameForm.id] = name === ''
+                ? 'Name must not be blank'
+                : '';
+
+            const ageForm = form.branch('age');
+            const age = ageForm.value;
+            validationMap[ageForm.id] = isNaN(parseFloat(age))
+                ? 'Age must be numeric'
+                : '';
+        });
+
+        validationForm.set(validationMap);
+    });
+
+    validationForm.useChange(newValue => {
+        console.log('newvalidation', newValue);
+    });
+
+    validationForm.branch('1').useChange(newValue => {
+        console.log('newvalidation 1', newValue);
+    });
+
+    validationForm.branch('2').useChange(newValue => {
+        console.log('newvalidation 2', newValue);
+    });
+
+    validationForm.branch('3').useChange(newValue => {
+        console.log('newvalidation 3', newValue);
+    });
+
+    const addNew = useCallback(() => form.set(array.push(BLANK_PERSON)), []);
+
+    return <Region>
+        {form.renderAll(form => {
+
+            const remove = useCallback(() => form.set(array.remove()), []);
+            const moveDown = useCallback(() => offsetElement(form, 1), []);
+            const moveUp = useCallback(() => offsetElement(form, -1), []);
+
+            return <Region>
+                {form.render('name', form => {
+                    return <Region>
+                        <label>name: <input {...useInput(form, 150)} /></label>
+                        {/*{validationForm.branch('2').value} - {validationForm.branch('2').useValue('name')}*/}
+                    </Region>;
+                })}
+                {form.render('age', form => (
+                    <Region>
+                        <label>age: {' '}<input {...useInput(form, 150)} /></label>
+                    </Region>
+                ))}
+
+                <button onClick={remove}>remove</button>
+                <button onClick={moveDown}>down</button>
+                <button onClick={moveUp}>up</button>
+            </Region>;
+        })}
+        <button onClick={addNew}>add new</button>
+    </Region>;
+}
+
+const ValidationCode = `
+const offsetElement = (form, offset) => {
+    return form.setParent(index => array.move(index, index + offset));
+};
+
+function MyComponent(props) {
+    ...
+}
+`;
+
+//
 // region
 //
 
@@ -1442,7 +1570,7 @@ type DemoObject = {
     Demo: React.ComponentType<Record<string, unknown>>;
     code: string;
     anchor: string;
-    more: string;
+    more?: string;
 };
 
 const DEMOS: DemoObject[] = [
@@ -1578,7 +1706,7 @@ const DEMOS: DemoObject[] = [
         title: 'Deriving data in another form',
         Demo: DerivingOther,
         code: DerivingOtherCode,
-        description: `It is also possible and often preferrable to make changes in other forms in .onDerive()'s callback. Here we can see that deriving data can be useful for implementing validation.`,
+        description: `It is also possible and often preferrable to make changes in other forms in .onDerive()'s callback. Here we can see that deriving data can be useful for implementing validation. Try deleting all the characters in the name below.`,
         anchor: 'deriveother',
         more: 'deriving-data'
     },
@@ -1594,7 +1722,7 @@ const DEMOS: DemoObject[] = [
         title: 'Synchronising forms with deriving',
         Demo: SyncDerive,
         code: SyncDeriveCode,
-        description: `The useSync() hook can also accept a deriver to derive data in one direction.`,
+        description: `The useSync() hook can also accept a deriver to derive data in one direction.  This has the effect of caching each derived form state in history, and calling undo and redo will just restore the relevant derived data at that point in history.`,
         anchor: 'syncderive',
         more: 'synchronising-forms'
     },
@@ -1605,6 +1733,13 @@ const DEMOS: DemoObject[] = [
         description: `An example of how one might implement drag and drop with react-beautiful-dnd. Dendriform's .renderAll() function, and its automatic id management on array elements simplifies this greatly.`,
         anchor: 'draganddrop',
         more: 'drag-and-drop'
+    },
+    {
+        title: 'Validation example',
+        Demo: Validation,
+        code: ValidationCode,
+        description: `An example of how it's possible to perform validation on an array of items.`,
+        anchor: 'validation'
     }
 ];
 
@@ -1633,7 +1768,7 @@ function Demo(props: DemoProps): React.ReactElement {
         </Flex>
         <Box mb={4}>
             <Text fontSize="smaller">
-                {description} {more && <Link title="To the documentation" href={`https://github.com/92green/dendriform#${more ?? ''}`}>docs {'>'}</Link>}
+                {description} {more && <Link title="To the documentation" href={`https://github.com/92green/dendriform#${more}`}>docs {'>'}</Link>}
             </Text>
         </Box>
         <DemoStyle>
@@ -1656,11 +1791,15 @@ function Demo(props: DemoProps): React.ReactElement {
     </DemoBox>;
 }
 
-const DemoBox =  styled.div`
+type DemoBoxProps = {
+    expanded: boolean;
+} & ThemeProps;
+
+const DemoBox =  styled.div<DemoBoxProps>`
     background-color: ${(props: ThemeProps) => props.theme.colors.background};
     width: 100%;
 
-    ${props => props.expanded
+    ${(props: DemoBoxProps) => props.expanded
         ? `
             position: fixed;
             top: 0;
@@ -1752,6 +1891,7 @@ const DemoPad =  styled.div`
 
 type CodeProps = {
     code: string;
+    className: string;
 };
 
 const Code = styled((props: CodeProps): React.ReactElement => {

--- a/packages/dendriform-demo/components/Demos.tsx
+++ b/packages/dendriform-demo/components/Demos.tsx
@@ -1441,51 +1441,36 @@ const BLANK_PERSON = {
 };
 
 type ValidationMap = {
+    all: string[];
     [id: string]: string;
 };
 
 function Validation(): React.ReactElement {
 
     const form = useDendriform<ValidationPerson[]>([BLANK_PERSON]);
-    const validationForm = useDendriform<ValidationMap>({});
+    const addNew = useCallback(() => form.set(array.push(BLANK_PERSON)), []);
 
+    // validation
+    const validationForm = useDendriform<ValidationMap>({all: []});
     form.useDerive(() => {
-        const validationMap: ValidationMap = {};
+        const validationMap: ValidationMap = {all: []};
 
         form.branchAll().forEach(form => {
             const nameForm = form.branch('name');
-            const name = nameForm.value;
-            validationMap[nameForm.id] = name === ''
-                ? 'Name must not be blank'
-                : '';
+            if(nameForm.value === '') {
+                validationMap[nameForm.id] = 'Name must not be blank';
+                validationMap.all.push(`Name #${form.index + 1} must not be blank`);
+            }
 
             const ageForm = form.branch('age');
-            const age = ageForm.value;
-            validationMap[ageForm.id] = isNaN(parseFloat(age))
-                ? 'Age must be numeric'
-                : '';
+            if(isNaN(parseFloat(ageForm.value))) {
+                validationMap[ageForm.id] = 'Age must be numeric';
+                validationMap.all.push(`Age #${form.index + 1} must be numeric`);
+            }
         });
 
         validationForm.set(validationMap);
     });
-
-    validationForm.useChange(newValue => {
-        console.log('newvalidation', newValue);
-    });
-
-    validationForm.branch('1').useChange(newValue => {
-        console.log('newvalidation 1', newValue);
-    });
-
-    validationForm.branch('2').useChange(newValue => {
-        console.log('newvalidation 2', newValue);
-    });
-
-    validationForm.branch('3').useChange(newValue => {
-        console.log('newvalidation 3', newValue);
-    });
-
-    const addNew = useCallback(() => form.set(array.push(BLANK_PERSON)), []);
 
     return <Region>
         {form.renderAll(form => {
@@ -1498,12 +1483,13 @@ function Validation(): React.ReactElement {
                 {form.render('name', form => {
                     return <Region>
                         <label>name: <input {...useInput(form, 150)} /></label>
-                        {/*{validationForm.branch('2').value} - {validationForm.branch('2').useValue('name')}*/}
+                        <Text fontSize="small">{validationForm.branch(form.id).useValue()}</Text>
                     </Region>;
                 })}
                 {form.render('age', form => (
                     <Region>
                         <label>age: {' '}<input {...useInput(form, 150)} /></label>
+                        <Text fontSize="small">{validationForm.branch(form.id).useValue()}</Text>
                     </Region>
                 ))}
 
@@ -1513,6 +1499,17 @@ function Validation(): React.ReactElement {
             </Region>;
         })}
         <button onClick={addNew}>add new</button>
+
+        {validationForm.render('all', form => {
+            const errors = form.useValue();
+            return <Region>
+                Errors:
+                <ul>
+                    {errors.map((err, key) => <Region of="li" key={key}>{err}</Region>)}
+                    {errors.length === 0 && <Region of="li">None</Region>}
+                </ul>
+            </Region>;
+        })}
     </Region>;
 }
 
@@ -1521,8 +1518,76 @@ const offsetElement = (form, offset) => {
     return form.setParent(index => array.move(index, index + offset));
 };
 
+const BLANK_PERSON = {
+    name: '',
+    age: ''
+};
+
 function MyComponent(props) {
-    ...
+    const form = useDendriform([BLANK_PERSON]);
+    const addNew = useCallback(() => form.set(array.push(BLANK_PERSON)), []);
+
+    // validation
+    const validationForm = useDendriform({all: []});
+    form.useDerive(() => {
+        const validationMap = {all: []};
+
+        form.branchAll().forEach(form => {
+            const nameForm = form.branch('name');
+            if(nameForm.value === '') {
+                validationMap[nameForm.id] = 'Name must not be blank';
+                validationMap.all.push(\`Name #\${form.index + 1} must not be blank\`);
+            }
+
+            const ageForm = form.branch('age');
+            if(isNaN(parseFloat(ageForm.value))) {
+                validationMap[ageForm.id] = 'Age must be numeric';
+                validationMap.all.push(\`Age #\${form.index + 1} must be numeric\`);
+            }
+        });
+
+        validationForm.set(validationMap);
+    });
+
+    return <>
+        {form.renderAll(form => {
+
+            const remove = useCallback(() => form.set(array.remove()), []);
+            const moveDown = useCallback(() => offsetElement(form, 1), []);
+            const moveUp = useCallback(() => offsetElement(form, -1), []);
+
+            return <>
+                {form.render('name', form => {
+                    return <>
+                        <label>name: <input {...useInput(form, 150)} /></label>
+                        <Text fontSize="small">{validationForm.branch(form.id).useValue()}</Text>
+                    </>;
+                })}
+                {form.render('age', form => (
+                    <>
+                        <label>age: {' '}<input {...useInput(form, 150)} /></label>
+                        <Text fontSize="small">{validationForm.branch(form.id).useValue()}</Text>
+                    </>
+                ))}
+
+                <button onClick={remove}>remove</button>
+                <button onClick={moveDown}>down</button>
+                <button onClick={moveUp}>up</button>
+            </>;
+        })}
+        <button onClick={addNew}>add new</button>
+
+        {validationForm.render('all', form => {
+            const errors = form.useValue();
+            return <>
+                Errors:
+                <ul>
+                    {errors.map((err, key) => <li key={key}>{err}</li>)}
+                    {errors.length === 0 && <li>None</li>}
+                </ul>
+            </>;
+        })}
+    </>;
 }
 `;
 

--- a/packages/dendriform-immer-patch-optimiser/src/traverse.ts
+++ b/packages/dendriform-immer-patch-optimiser/src/traverse.ts
@@ -3,9 +3,11 @@ export const OBJECT = 1;
 export const ARRAY = 2;
 export const MAP = 3;
 
+export type DataType = typeof ARRAY|typeof OBJECT|typeof BASIC|typeof MAP;
+
 const cantAccess = (thing: unknown, key: PropertyKey) => new Error(`Cant access property ${String(key)} of ${String(thing)}`);
 
-export function getType(thing: unknown): typeof ARRAY|typeof OBJECT|typeof BASIC|typeof MAP {
+export function getType(thing: unknown): DataType {
     if(thing instanceof Map) return MAP;
     if(Array.isArray(thing)) return ARRAY;
     if(thing instanceof Object) return OBJECT;
@@ -80,4 +82,12 @@ export function clone(thing: any): any {
     if(type === ARRAY) return thing.slice();
     if(type === MAP) return new Map(thing);
     return thing;
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+export function create(type: DataType): any {
+    if(type === OBJECT) return {};
+    if(type === ARRAY) return [];
+    if(type === MAP) return new Map();
+    return undefined;
 }

--- a/packages/dendriform-immer-patch-optimiser/test/traverse.test.ts
+++ b/packages/dendriform-immer-patch-optimiser/test/traverse.test.ts
@@ -1,4 +1,4 @@
-import {BASIC, OBJECT, ARRAY, MAP, getType, has, get, getIn, set, each, clone} from '../src/index';
+import {BASIC, OBJECT, ARRAY, MAP, getType, has, get, getIn, set, each, clone, create} from '../src/index';
 
 describe(`getType`, () => {
     test(`should identify basics`, () => {
@@ -217,5 +217,23 @@ describe(`clone`, () => {
         expect(cloned).not.toBe(map);
         expect(cloned.get('foo')).toBe(1);
         expect(cloned.get('bar')).toBe(2);
+    });
+});
+
+describe(`create`, () => {
+    test(`BASIC should create undefined`, () => {
+        expect(create(BASIC)).toBe(undefined);
+    });
+
+    test(`OBJECT should create object`, () => {
+        expect(create(OBJECT)).toEqual({});
+    });
+
+    test(`ARRAY should create array`, () => {
+        expect(create(ARRAY)).toEqual([]);
+    });
+
+    test(`MAP should create map`, () => {
+        expect(create(MAP) instanceof Map).toBe(true);
     });
 });

--- a/packages/dendriform/src/Dendriform.tsx
+++ b/packages/dendriform/src/Dendriform.tsx
@@ -573,7 +573,7 @@ export class Dendriform<V,C=V> {
     }
 
     useIndex(): number {
-        const [index, setIndex] = useState<number>(() => this.core.getIndex(this.id));
+        const [index, setIndex] = useState<number>(() => this.index);
         this.useChange(setIndex, 'index');
         return index;
     }

--- a/packages/dendriform/src/Dendriform.tsx
+++ b/packages/dendriform/src/Dendriform.tsx
@@ -331,7 +331,7 @@ class Core<C> {
         patches: HistoryPatch
     ): void => {
         // only update a callback if it is not equal to the previous value
-        const [,id, changeCallback, prevValue] = changeCallbackRef;
+        const [,, changeCallback, prevValue] = changeCallbackRef;
         if(!Object.is(nextValue, prevValue)) {
             changeCallback(nextValue, {patches});
             changeCallbackRef[3] = nextValue;

--- a/packages/dendriform/src/Nodes.ts
+++ b/packages/dendriform/src/Nodes.ts
@@ -1,45 +1,38 @@
-import {BASIC, OBJECT, ARRAY, MAP, getType, has, get, set, each, clone, applyPatches} from 'dendriform-immer-patch-optimiser';
+import {BASIC, OBJECT, ARRAY, MAP, getType, get, set, each, create, applyPatches} from 'dendriform-immer-patch-optimiser';
 import type {Path, DendriformPatch} from 'dendriform-immer-patch-optimiser';
-import {produceWithPatches, setAutoFreeze} from 'immer';
+import {produceWithPatches} from 'immer';
 
-// never autofreeze, this stops us from mutating node.child
-// node.child is a safe mutation as the tree / nodes are entirely internal
-setAutoFreeze(false);
+export type NodeCommon = {
+    id: string;
+    parentId: string;
+};
 
 export type NodeObject = {
     type: typeof OBJECT;
     child?: {[key: string]: string};
-    id: string;
-    parentId: string;
-};
+} & NodeCommon;
 
 export type NodeArray = {
     type: typeof ARRAY;
     child?: string[];
-    id: string;
-    parentId: string;
-};
+} & NodeCommon;
 
 export type NodeMap = {
     type: typeof MAP;
     child?: Map<string|number,string>;
-    id: string;
-    parentId: string;
-};
+} & NodeCommon;
 
 export type NodeBasic = {
     type: typeof BASIC;
     child: undefined;
-    id: string;
-    parentId: string;
-};
+} & NodeCommon;
 
 export type NodeAny = NodeObject|NodeArray|NodeBasic|NodeMap;
 
 export type Nodes = {[id: string]: NodeAny};
 
 export type CountRef = {
-    current: number
+    current: number;
 };
 
 export type NewNodeCreator = (value: unknown, parentId?: string) => NodeAny;
@@ -50,7 +43,7 @@ export const newNode = (countRef: CountRef): NewNodeCreator => {
         const id = `${countRef.current++}`;
         return {
             type,
-            child: undefined,
+            child: create(type),
             parentId,
             id
         };
@@ -61,69 +54,47 @@ export const addNode = (nodes: Nodes, node: NodeAny): void => {
     nodes[node.id] = node;
 };
 
-export const _prepChild = <P>(
-    nodes: Nodes,
-    newNodeCreator: NewNodeCreator,
-    parentValueRef: P,
-    parentNode: NodeAny
-): void => {
-
-    if(parentNode.type === BASIC || parentNode.child) return;
-
-    const child: string[]|{[key: string]: string}|Map<string|number,string> = parentNode.type === MAP
-        ? new Map()
-        : parentNode.type === ARRAY
-            ? []
-            : {};
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    each(parentValueRef, (value, key: any) => {
-        const childNode = newNodeCreator(value, parentNode.id);
-        addNode(nodes, childNode);
-        return set(child, key, childNode.id);
-    });
-    parentNode.child = child;
-};
-
 export const getNode = (nodes: Nodes, id: string): NodeAny|undefined => {
     return nodes[id];
+};
+
+const _getOrCreateChild = <P = unknown>(nodes: Nodes, newNodeCreator: NewNodeCreator, parentNode: NodeAny, childValueRef: P, key: string|number): NodeAny|undefined => {
+    const childId = get(parentNode.child, key);
+    if(typeof childId === 'string') {
+        return getNode(nodes, childId);
+    }
+
+    const childNode = newNodeCreator(childValueRef, parentNode.id);
+
+    addNode(nodes, childNode);
+    set(parentNode.child, key, childNode.id);
+    return childNode;
 };
 
 export const getNodeByPath = <P = unknown>(
     nodes: Nodes,
     newNodeCreator: NewNodeCreator,
     valueRef: P,
-    path: Path,
-    andChildren?: boolean
+    path: Path
 ): NodeAny|undefined => {
 
+    let node: NodeAny|undefined = nodes['0'];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let valueRefAny = valueRef as any;
-    let node: NodeAny|undefined = nodes['0'];
 
     for(const key of path) {
-        if(!node || node.type === BASIC) return undefined;
-
-        if(!has(valueRefAny, key)) {
-            valueRefAny = clone(valueRefAny);
-            set(valueRefAny, key, undefined);
+        if(!node || node.type === BASIC) {
+            node = undefined;
+        } else {
+            valueRefAny = get(valueRefAny, key);
+            node = _getOrCreateChild(nodes, newNodeCreator, node, valueRefAny, key);
         }
-
-        _prepChild<P>(nodes, newNodeCreator, valueRefAny, node);
-
-        const nextId = get(node.child, key) as string;
-        node = getNode(nodes, nextId);
-        valueRefAny = get(valueRefAny, key);
-    }
-
-    if(andChildren && node) {
-        _prepChild<P>(nodes, newNodeCreator, valueRefAny, node);
     }
 
     return node;
 };
 
-export const _getKey = (parentNode: NodeAny, childNode: NodeAny): number|string|undefined => {
+const _getKey = (parentNode: NodeAny, childNode: NodeAny): number|string|undefined => {
     let key = undefined;
     each(parentNode.child, (childId, childKey) => {
         if(childId === childNode.id) {
@@ -170,7 +141,7 @@ export const updateNode = (nodes: Nodes, id: string, value: unknown): void => {
     nodes[id] = {
         ...node,
         type,
-        child: undefined
+        child: create(type)
     };
 };
 
@@ -193,19 +164,13 @@ export const produceNodePatches = (
                 return;
             }
 
-            const parentNode = getNodeByPath(
-                nodes,
-                newNodeCreator,
-                baseValue,
-                path.slice(0,-1),
-                true
-            );
-
+            const parentNode = getNodeByPath(draft, newNodeCreator, baseValue, path.slice(0,-1));
             if(!parentNode) return;
+
+            const getChildId = (): string => getNodeByPath(draft, newNodeCreator, baseValue, path)?.id as string;
 
             const basePath = [parentNode.id, 'child'];
             const key = path[path.length - 1];
-            const childId = get(parentNode.child, key) as string;
 
             // depending on type, make changes to the child node
             // and to the parent node's child
@@ -219,14 +184,14 @@ export const produceNodePatches = (
                 });
 
             } else if(op === 'remove') {
-                removeNode(draft, childId);
+                removeNode(draft, getChildId());
                 patchesForNodes.push({
                     op,
                     path: [...basePath, key]
                 });
 
             } else if(op === 'replace') {
-                updateNode(draft, childId, value);
+                updateNode(draft, getChildId(), value);
 
             } else if(op === 'move' && patch.from) {
                 const fromKey = patch.from[patch.from.length - 1];
@@ -237,6 +202,8 @@ export const produceNodePatches = (
                 });
             }
         });
+
+        // console.log('draft', JSON.stringify(draft, null, 2));
 
         // apply the patches to change parent node's children
         // (immer's produceWithPatches will collect the mutations)

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -498,9 +498,16 @@ describe(`Dendriform`, () => {
             const form = new Dendriform(['A','B','C']);
 
             const bForm = form.branch(1);
-
             expect(bForm.value).toBe('B');
-            expect(bForm.id).toBe('2');
+            expect(bForm.id).toBe('1');
+
+            const cForm = form.branch(2);
+            expect(cForm.value).toBe('C');
+            expect(cForm.id).toBe('2');
+
+            const bFormAgain = form.branch(1);
+            expect(bFormAgain.value).toBe('B');
+            expect(bFormAgain.id).toBe('1');
         });
 
         test(`should produce child value with new value`, () => {
@@ -537,6 +544,7 @@ describe(`Dendriform`, () => {
             test(`should get child value`, () => {
                 const form = new Dendriform<NotSetTestValue>({foo: 'a'});
 
+                form.branch('foo');
                 const bForm = form.branch('bar');
 
                 expect(bForm.value).toBe(undefined);

--- a/packages/dendriform/test/Nodes.test.ts
+++ b/packages/dendriform/test/Nodes.test.ts
@@ -1,13 +1,32 @@
 import {newNode, addNode, getNode, getPath, getNodeByPath, updateNode, removeNode, produceNodePatches} from '../src/index';
 import type {Nodes, NodeAny, NewNodeCreator} from '../src/index';
 import {BASIC, OBJECT, ARRAY, MAP, applyPatches} from 'dendriform-immer-patch-optimiser';
+import type {Path} from 'dendriform-immer-patch-optimiser';
+import produce from 'immer';
 
 const createNodesFrom = (value: unknown): [Nodes, NewNodeCreator] => {
-    const nodes = {};
     const countRef = {current: 0};
     const newNodeCreator = newNode(countRef);
-    addNode(nodes, newNodeCreator(value));
+
+    // use immer to add this, because immer freezes things and the tests must cope with that
+    const nodes = produce({}, draft => {
+        addNode(draft, newNodeCreator(value));
+    });
+
     return [nodes, newNodeCreator];
+};
+
+const produceNodeByPath = <P = unknown>(
+    nodes: Nodes,
+    newNodeCreator: NewNodeCreator,
+    valueRef: P,
+    path: Path
+): [Nodes, NodeAny|undefined] => {
+    let node;
+    const newNodes = produce(nodes, draft => {
+        node = getNodeByPath(draft, newNodeCreator, valueRef, path);
+    });
+    return [newNodes, node];
 };
 
 describe(`Nodes`, () => {
@@ -62,7 +81,7 @@ describe(`Nodes`, () => {
 
             expect(newNode(countRef)(obj)).toEqual({
                 type: OBJECT,
-                child: undefined,
+                child: {},
                 parentId: '',
                 id: '0'
             });
@@ -77,7 +96,7 @@ describe(`Nodes`, () => {
 
             expect(newNode(countRef)(arr)).toEqual({
                 type: ARRAY,
-                child: undefined,
+                child: [],
                 parentId: '',
                 id: '0'
             });
@@ -95,7 +114,7 @@ describe(`Nodes`, () => {
 
             expect(newNode(countRef)(map)).toEqual({
                 type: MAP,
-                child: undefined,
+                child: new Map(),
                 parentId: '',
                 id: '0'
             });
@@ -108,7 +127,7 @@ describe(`Nodes`, () => {
 
             const node: NodeAny = {
                 type: OBJECT,
-                child: undefined,
+                child: {},
                 parentId: '',
                 id: '0'
             };
@@ -136,7 +155,7 @@ describe(`Nodes`, () => {
         test(`should get node if its there`, () => {
             const node: NodeAny = {
                 type: OBJECT,
-                child: undefined,
+                child: {},
                 parentId: '',
                 id: '0'
             };
@@ -156,56 +175,80 @@ describe(`Nodes`, () => {
             const value = 123;
             const [nodes, newNodeCreator] = createNodesFrom(value);
 
-            expect(getNodeByPath(nodes, newNodeCreator, value, ['foo'])).toBe(undefined);
+            expect(produceNodeByPath(nodes, newNodeCreator, value, ['foo'])[1]).toBe(undefined);
         });
 
         test(`should accept objects and getNodeByPath()`, () => {
             const value = {foo: 'foo!', bar: 'bar!'};
             const [nodes, newNodeCreator] = createNodesFrom(value);
 
-            expect(getNodeByPath(nodes, newNodeCreator, value, ['foo'])).toEqual({
+            const [newNodes, node] = produceNodeByPath(nodes, newNodeCreator, value, ['foo']);
+
+            expect(node).toEqual({
                 type: BASIC,
                 child: undefined,
                 parentId: '0',
                 id: '1'
             });
 
-            expect(nodes['0'].child).toEqual({
+            expect(newNodes['0'].child).toEqual({
+                foo: '1'
+            });
+
+            expect(newNodes['1']).toEqual({
+                type: BASIC,
+                child: undefined,
+                parentId: '0',
+                id: '1'
+            });
+
+            const [newNodes2, node2] = produceNodeByPath(newNodes, newNodeCreator, value, ['bar']);
+
+            expect(node2).toEqual({
+                type: BASIC,
+                child: undefined,
+                parentId: '0',
+                id: '2'
+            });
+
+            expect(newNodes2['0'].child).toEqual({
                 foo: '1',
                 bar: '2'
             });
 
-            expect(nodes['1']).toEqual({
+            expect(newNodes2['2']).toEqual({
                 type: BASIC,
                 child: undefined,
                 parentId: '0',
-                id: '1'
+                id: '2'
             });
         });
 
         test(`should accept objects and getNodeByPath() deep`, () => {
             const value = {foo: {bar: 'bar!'}};
             const [nodes, newNodeCreator] = createNodesFrom(value);
+            const [newNodes, node] = produceNodeByPath(nodes, newNodeCreator, value, ['foo']);
 
-            expect(getNodeByPath(nodes, newNodeCreator, value, ['foo'])).toEqual({
+            expect(node).toEqual({
                 type: OBJECT,
-                child: undefined,
+                child: {},
                 parentId: '0',
                 id: '1'
             });
 
-            expect(nodes['0'].child).toEqual({
+            expect(newNodes['0'].child).toEqual({
                 foo: '1'
             });
 
-            expect(getNodeByPath(nodes, newNodeCreator, value, ['foo', 'bar'])).toEqual({
+            const [newNodes2, node2] = produceNodeByPath(newNodes, newNodeCreator, value, ['foo','bar']);
+            expect(node2).toEqual({
                 type: BASIC,
                 child: undefined,
                 parentId: '1',
                 id: '2'
             });
 
-            expect(nodes['1'].child).toEqual({
+            expect(newNodes2['1'].child).toEqual({
                 bar: '2'
             });
         });
@@ -213,18 +256,17 @@ describe(`Nodes`, () => {
         test(`should accept objects and getNodeByPath() should return basic node if nothing at path`, () => {
             const value = {foo: 'foo!', bar: 'bar!'};
             const [nodes, newNodeCreator] = createNodesFrom(value);
+            const [newNodes, node] = produceNodeByPath(nodes, newNodeCreator, value, ['baz']);
 
-            expect(getNodeByPath(nodes, newNodeCreator, value, ['baz'])).toEqual({
+            expect(node).toEqual({
                 type: BASIC,
                 child: undefined,
                 parentId: '0',
-                id: '3'
+                id: '1'
             });
 
-            expect(nodes['0'].child).toEqual({
-                foo: '1',
-                bar: '2',
-                baz: '3'
+            expect(newNodes['0'].child).toEqual({
+                baz: '1'
             });
 
             // make sure no mutations have occurred
@@ -234,30 +276,43 @@ describe(`Nodes`, () => {
         test(`should accept arrays and getNodeByPath()`, () => {
             const value = ['a','b','c'];
             const [nodes, newNodeCreator] = createNodesFrom(value);
+            const [newNodes, node] = produceNodeByPath(nodes, newNodeCreator, value, [2]);
 
-            expect(getNodeByPath(nodes, newNodeCreator, value, [2])).toEqual({
+            expect(node).toEqual({
                 type: BASIC,
                 child: undefined,
                 parentId: '0',
-                id: '3'
+                id: '1'
             });
 
             // internal child check
-            expect(nodes['0'].child).toEqual(['1','2','3']);
+            expect(newNodes['0'].child).toEqual([undefined,undefined,'1']);
         });
 
         test(`should accept arrays and getNodeByPath() and return basic node if nothing at path`, () => {
             const value = ['a','b','c'];
             const [nodes, newNodeCreator] = createNodesFrom(value);
+            const [newNodes, node] = produceNodeByPath(nodes, newNodeCreator, value, [3]);
 
-            expect(getNodeByPath(nodes, newNodeCreator, value, [3])).toEqual({
+            expect(node).toEqual({
                 type: BASIC,
                 child: undefined,
                 parentId: '0',
-                id: '4'
+                id: '1'
             });
 
-            expect(nodes['0'].child).toEqual(['1','2','3','4']);
+            expect(newNodes['0'].child).toEqual([undefined,undefined,undefined,'1']);
+
+            const [newNodes2, node2] = produceNodeByPath(newNodes, newNodeCreator, value, [0]);
+
+            expect(node2).toEqual({
+                type: BASIC,
+                child: undefined,
+                parentId: '0',
+                id: '2'
+            });
+
+            expect(newNodes2['0'].child).toEqual(['2',undefined,undefined,'1']);
         });
     });
 
@@ -277,9 +332,9 @@ describe(`Nodes`, () => {
             const value = {foo: 'foo!', bar: 'bar!'};
             const [nodes, newNodeCreator] = createNodesFrom(value);
             // create child nodes first
-            getNodeByPath(nodes, newNodeCreator, value, ['bar']);
+            const [newNodes] = produceNodeByPath(nodes, newNodeCreator, value, ['bar']);
             // run test
-            expect(getPath(nodes, '2')).toEqual(['bar']);
+            expect(getPath(newNodes, '1')).toEqual(['bar']);
         });
     });
 
@@ -288,27 +343,29 @@ describe(`Nodes`, () => {
             const value = {foo: {bar: 'bar!'}, baz: 'baz!'};
             const [nodes, newNodeCreator] = createNodesFrom(value);
             // create child nodes first
-            getNodeByPath(nodes, newNodeCreator, value, ['foo','bar']);
-            expect(Object.keys(nodes)).toEqual(['0','1','2','3']);
+            const [newNodes] = produceNodeByPath(nodes, newNodeCreator, value, ['foo','bar']);
+            const [newNodes2] = produceNodeByPath(newNodes, newNodeCreator, value, ['baz']);
+
+            expect(Object.keys(newNodes2)).toEqual(['0','1','2','3']);
 
             // run test
-            removeNode(nodes, '1');
-            expect(Object.keys(nodes)).toEqual(['0','2']);
+            const newNodes3 = produce(newNodes2, draft => removeNode(draft, '1'));
+            expect(Object.keys(newNodes3)).toEqual(['0','3']);
         });
 
         test(`should no nothing if node doesnt exist`, () => {
             const value = {foo: {bar: 'bar!'}, baz: 'baz!'};
             const [nodes, newNodeCreator] = createNodesFrom(value);
             // create child nodes first
-            getNodeByPath(nodes, newNodeCreator, value, ['foo','bar']);
+            const [newNodes] = produceNodeByPath(nodes, newNodeCreator, value, ['foo','bar']);
 
-            const nodesBefore = JSON.stringify(nodes);
+            const nodesBefore = JSON.stringify(newNodes);
 
             // run test
-            removeNode(nodes, '1888');
+            const newNodes2 = produce(newNodes, draft => removeNode(draft, '1888'));
 
             // should be the same still
-            expect(JSON.stringify(nodes)).toBe(nodesBefore);
+            expect(JSON.stringify(newNodes2)).toBe(nodesBefore);
         });
     });
 
@@ -318,15 +375,15 @@ describe(`Nodes`, () => {
             const value = ['a','b','c'];
             const [nodes, newNodeCreator] = createNodesFrom(value);
             // create child nodes first
-            getNodeByPath(nodes, newNodeCreator, value, [2]);
+            const [newNodes] = produceNodeByPath(nodes, newNodeCreator, value, [2]);
             // run test
-            updateNode(nodes, '3', {c: 'd'});
+            const newNodes2 = produce(newNodes, draft => updateNode(draft, '1', {c: 'd'}));
             // internal child check
-            expect(nodes['3']).toEqual({
+            expect(newNodes2['1']).toEqual({
                 type: OBJECT,
-                child: undefined,
+                child: {},
                 parentId: '0',
-                id: '3'
+                id: '1'
             });
         });
 
@@ -334,36 +391,33 @@ describe(`Nodes`, () => {
             const value = ['a','b',{c:'d'}];
             const [nodes, newNodeCreator] = createNodesFrom(value);
             // create child nodes first
-            getNodeByPath(nodes, newNodeCreator, value, [2,'c']);
-            expect(nodes['3'].child).toEqual({c: '4'});
-            expect(Object.keys(nodes)).toEqual(['0','1','2','3','4']);
+            const [newNodes] = produceNodeByPath(nodes, newNodeCreator, value, [2,'c']);
+            expect(newNodes['1'].child).toEqual({c: '2'});
 
             // run test
-            updateNode(nodes, '3','d');
+            const newNodes2 = produce(newNodes, draft => updateNode(draft, '1', 'd'));
             // internal child check
-            expect(nodes['3']).toEqual({
+            expect(newNodes2['1']).toEqual({
                 type: BASIC,
                 child: undefined,
                 parentId: '0',
-                id: '3'
+                id: '1'
             });
-            // internal node check
-            expect(Object.keys(nodes)).toEqual(['0','1','2','3']);
         });
 
         test(`should do nothing if node doesnt exist`, () => {
             const value = ['a','b','c'];
             const [nodes, newNodeCreator] = createNodesFrom(value);
             // create child nodes first
-            getNodeByPath(nodes, newNodeCreator, value, [2]);
+            const [newNodes] = produceNodeByPath(nodes, newNodeCreator, value, [2]);
 
-            const nodesBefore = JSON.stringify(nodes);
+            const nodesBefore = JSON.stringify(newNodes);
 
             // run test
-            updateNode(nodes, '389890890', {c: 'd'});
+            const newNodes2 = produce(newNodes, draft => updateNode(draft, '389890890', {c: 'd'}));
 
             // should be the same still
-            expect(JSON.stringify(nodes)).toBe(nodesBefore);
+            expect(JSON.stringify(newNodes2)).toBe(nodesBefore);
         });
 
     });
@@ -375,14 +429,27 @@ describe(`Nodes`, () => {
             test(`${msg}, without premade child nodes`, () => fn(false));
         };
 
+        const premakeTopFooBar = (newNodeCreator: NewNodeCreator, nodes: Nodes, value: unknown): Nodes => {
+            const [newNodes1] = produceNodeByPath(nodes, newNodeCreator, value, ['top','foo']);
+            const [newNodes2] = produceNodeByPath(newNodes1, newNodeCreator, value, ['top','bar']);
+            return newNodes2;
+        };
+
+        const premakeArrayNodes = (newNodeCreator: NewNodeCreator, nodes: Nodes, value: unknown): Nodes => {
+            const [newNodes1] = produceNodeByPath(nodes, newNodeCreator, value, [0]);
+            const [newNodes2] = produceNodeByPath(newNodes1, newNodeCreator, value, [1]);
+            const [newNodes3] = produceNodeByPath(newNodes2, newNodeCreator, value, [2]);
+            return newNodes3;
+        };
+
         describe(`should be able to apply object patches`, () => {
             testNodePatches(`of type "add"`, (premakeChildNodes) => {
                 const value = {top: {foo: 1, bar: 2}};
                 const [nodes, newNodeCreator] = createNodesFrom(value);
 
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, ['top','foo']);
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, ['top','bar']);
-                const nodesBefore = nodes;
+                const nodesBefore = premakeChildNodes
+                    ? premakeTopFooBar(newNodeCreator, nodes, value)
+                    : nodes;
 
                 const patches = [
                     {op: 'add', path: ['top','baz'], value: 3}
@@ -391,23 +458,18 @@ describe(`Nodes`, () => {
                 const newValue = applyPatches(value, patches);
                 expect(newValue).toEqual({top: {foo: 1, bar: 2, baz: 3}});
 
-                const [newNodes] = produceNodePatches(nodes, newNodeCreator, value, patches);
+                const [newNodes] = produceNodePatches(nodesBefore, newNodeCreator, value, patches);
 
-                expect(newNodes).toEqual({
-                    ...nodesBefore,
-                    ['1']: {
-                        ...nodesBefore['1'],
-                        child: {
-                            ...nodesBefore['1'].child,
-                            baz: '4'
-                        }
-                    },
-                    ['4']: {
-                        child: undefined,
-                        id: '4',
-                        parentId: '1',
-                        type: BASIC
-                    }
+                const topChild = newNodes['1']?.child || {};
+                expect('baz' in topChild).toBe(true);
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                const newId: string = topChild.baz;
+                expect(newNodes[newId]).toEqual({
+                    id: newId,
+                    parentId: '1',
+                    type: 0,
+                    child: undefined
                 });
             });
 
@@ -415,9 +477,9 @@ describe(`Nodes`, () => {
                 const value = {top: {foo: 1, bar: 2}};
                 const [nodes, newNodeCreator] = createNodesFrom(value);
 
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, ['top','foo']);
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, ['top','bar']);
-                const nodesBefore = nodes;
+                const nodesBefore = premakeChildNodes
+                    ? premakeTopFooBar(newNodeCreator, nodes, value)
+                    : nodes;
 
                 const patches = [
                     {op: 'remove', path: ['top','bar']}
@@ -426,28 +488,24 @@ describe(`Nodes`, () => {
                 const newValue = applyPatches(value, patches);
                 expect(newValue).toEqual({top: {foo: 1}});
 
-                const [newNodes] = produceNodePatches(nodes, newNodeCreator, value, patches);
+                const [newNodes] = produceNodePatches(nodesBefore, newNodeCreator, value, patches);
 
-                expect(newNodes).toEqual({
-                    ['0']: nodesBefore['0'],
-                    ['1']: {
-                        ...nodesBefore['1'],
-                        child: {
-                            foo: '2'
-                        }
-                    },
-                    ['2']: nodesBefore['2']
-                    // 3 should be missing
-                });
+                const topChild = newNodes['1']?.child || {};
+                expect('baz' in topChild).toBe(false);
+
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                const oldId = (nodesBefore['1']?.child || {}).bar;
+                expect(oldId in newNodes).toBe(false);
             });
 
             testNodePatches(`of type "remove" parent`, (premakeChildNodes) => {
                 const value = {top: {foo: 1, bar: 2}};
                 const [nodes, newNodeCreator] = createNodesFrom(value);
 
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, ['top','foo']);
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, ['top','bar']);
-                const nodesBefore = nodes;
+                const nodesBefore = premakeChildNodes
+                    ? premakeTopFooBar(newNodeCreator, nodes, value)
+                    : nodes;
 
                 const patches = [
                     {op: 'remove', path: ['top']}
@@ -456,24 +514,21 @@ describe(`Nodes`, () => {
                 const newValue = applyPatches(value, patches);
                 expect(newValue).toEqual({});
 
-                const [newNodes] = produceNodePatches(nodes, newNodeCreator, value, patches);
+                const [newNodes] = produceNodePatches(nodesBefore, newNodeCreator, value, patches);
 
-                expect(newNodes).toEqual({
-                    ['0']: {
-                        ...nodesBefore['0'],
-                        child: {}
-                    }
-                    // everything else should be missing
-                });
+                const rootChild = newNodes['0']?.child || {};
+                expect('top' in rootChild).toBe(false);
+
+                expect(Object.keys(newNodes)).toEqual(['0']);
             });
 
             testNodePatches(`of type "replace"`, (premakeChildNodes) => {
                 const value = {top: {foo: 1, bar: 2}};
                 const [nodes, newNodeCreator] = createNodesFrom(value);
 
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, ['top','foo']);
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, ['top','bar']);
-                const nodesBefore = nodes;
+                const nodesBefore = premakeChildNodes
+                    ? premakeTopFooBar(newNodeCreator, nodes, value)
+                    : nodes;
 
                 const patches = [
                     {op: 'replace', path: ['top','bar'], value: 3}
@@ -482,18 +537,24 @@ describe(`Nodes`, () => {
                 const newValue = applyPatches(value, patches);
                 expect(newValue).toEqual({top: {foo: 1, bar: 3}});
 
-                const [newNodes] = produceNodePatches(nodes, newNodeCreator, value, patches);
+                const [newNodes] = produceNodePatches(nodesBefore, newNodeCreator, value, patches);
 
-                expect(newNodes).toEqual(nodesBefore);
+                const topChild = newNodes['1']?.child || {};
+                expect('bar' in topChild).toBe(true);
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                const barId: string = topChild.bar;
+
+                expect(newNodes[barId]?.type).toBe(0);
             });
 
             testNodePatches(`of type "replace" and change type`, (premakeChildNodes) => {
                 const value = {top: {foo: 1, bar: 2}};
                 const [nodes, newNodeCreator] = createNodesFrom(value);
 
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, ['top','foo']);
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, ['top','bar']);
-                const nodesBefore = nodes;
+                const nodesBefore = premakeChildNodes
+                    ? premakeTopFooBar(newNodeCreator, nodes, value)
+                    : nodes;
 
                 const patches = [
                     {op: 'replace', path: ['top','bar'], value: []}
@@ -502,29 +563,24 @@ describe(`Nodes`, () => {
                 const newValue = applyPatches(value, patches);
                 expect(newValue).toEqual({top: {foo: 1, bar: []}});
 
-                const [newNodes] = produceNodePatches(nodes, newNodeCreator, value, patches);
+                const [newNodes] = produceNodePatches(nodesBefore, newNodeCreator, value, patches);
 
-                expect(newNodes).toEqual({
-                    ...nodesBefore,
-                    ['3']: {
-                        child: undefined,
-                        id: '3',
-                        parentId: '1',
-                        type: ARRAY
-                    }
-                });
+                const topChild = newNodes['1']?.child || {};
+                expect('bar' in topChild).toBe(true);
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                const barId: string = topChild.bar;
+
+                expect(newNodes[barId]?.type).toBe(ARRAY);
             });
         });
 
         describe(`should be able to apply array patches`, () => {
-            testNodePatches(`of type "add"`, (premakeChildNodes) => {
+            test(`of type "add"`, () => {
                 const value = ['a','b','c'];
                 const [nodes, newNodeCreator] = createNodesFrom(value);
 
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, [0]);
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, [1]);
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, [2]);
-                const nodesBefore = nodes;
+                const nodesBefore = premakeArrayNodes(newNodeCreator, nodes, value);
 
                 const patches = [
                     {op: 'add', path: [1], value: 'd'}
@@ -533,7 +589,7 @@ describe(`Nodes`, () => {
                 const newValue = applyPatches(value, patches);
                 expect(newValue).toEqual(['a','d','b','c']);
 
-                const [newNodes] = produceNodePatches(nodes, newNodeCreator, value, patches);
+                const [newNodes] = produceNodePatches(nodesBefore, newNodeCreator, value, patches);
 
                 expect(newNodes).toEqual({
                     ...nodesBefore,
@@ -550,14 +606,11 @@ describe(`Nodes`, () => {
                 });
             });
 
-            testNodePatches(`of type "remove"`, (premakeChildNodes) => {
+            test(`of type "remove"`, () => {
                 const value = ['a','b','c'];
                 const [nodes, newNodeCreator] = createNodesFrom(value);
 
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, [0]);
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, [1]);
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, [2]);
-                const nodesBefore = nodes;
+                const nodesBefore = premakeArrayNodes(newNodeCreator, nodes, value);
 
                 const patches = [
                     {op: 'remove', path: [1]}
@@ -566,7 +619,7 @@ describe(`Nodes`, () => {
                 const newValue = applyPatches(value, patches);
                 expect(newValue).toEqual(['a','c']);
 
-                const [newNodes] = produceNodePatches(nodes, newNodeCreator, value, patches);
+                const [newNodes] = produceNodePatches(nodesBefore, newNodeCreator, value, patches);
 
                 expect(newNodes).toEqual({
                     ['0']: {
@@ -579,14 +632,11 @@ describe(`Nodes`, () => {
                 });
             });
 
-            testNodePatches(`of type "replace"`, (premakeChildNodes) => {
+            test(`of type "replace"`, () => {
                 const value = ['a','b','c'];
                 const [nodes, newNodeCreator] = createNodesFrom(value);
 
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, [0]);
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, [1]);
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, [2]);
-                const nodesBefore = nodes;
+                const nodesBefore = premakeArrayNodes(newNodeCreator, nodes, value);
 
                 const patches = [
                     {op: 'replace', path: [1], value: '?'}
@@ -595,19 +645,16 @@ describe(`Nodes`, () => {
                 const newValue = applyPatches(value, patches);
                 expect(newValue).toEqual(['a','?','c']);
 
-                const [newNodes] = produceNodePatches(nodes, newNodeCreator, value, patches);
+                const [newNodes] = produceNodePatches(nodesBefore, newNodeCreator, value, patches);
 
                 expect(newNodes).toEqual(nodesBefore);
             });
 
-            testNodePatches(`of type "move"`, (premakeChildNodes) => {
+            test(`of type "move"`, () => {
                 const value = ['a','b','c'];
                 const [nodes, newNodeCreator] = createNodesFrom(value);
 
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, [0]);
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, [1]);
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, [2]);
-                const nodesBefore = nodes;
+                const nodesBefore = premakeArrayNodes(newNodeCreator, nodes, value);
 
                 const patches = [
                     {op: 'move', from: [2], path: [1]}
@@ -616,7 +663,7 @@ describe(`Nodes`, () => {
                 const newValue = applyPatches(value, patches);
                 expect(newValue).toEqual(['a','c','b']);
 
-                const [newNodes] = produceNodePatches(nodes, newNodeCreator, value, patches);
+                const [newNodes] = produceNodePatches(nodesBefore, newNodeCreator, value, patches);
 
                 expect(newNodes).toEqual({
                     ...nodesBefore,
@@ -627,35 +674,23 @@ describe(`Nodes`, () => {
                 });
             });
 
-            testNodePatches(`of type "remove", setting childKeys correctly with getPath()`, (premakeChildNodes) => {
+            test(`of type "remove", setting childKeys correctly with getPath()`, () => {
                 const value = ['a','b','c'];
                 const [nodes, newNodeCreator] = createNodesFrom(value);
 
-                if(premakeChildNodes) {
+                const nodesBefore = premakeArrayNodes(newNodeCreator, nodes, value);
 
-                    getNodeByPath(nodes, newNodeCreator, value, [0]);
-                    getNodeByPath(nodes, newNodeCreator, value, [1]);
-                    getNodeByPath(nodes, newNodeCreator, value, [2]);
-
-                    // expect(nodes['0'].childKeysCached).toBe(undefined);
-
-                    const path = getPath(nodes, '2');
-                    expect(path).toEqual([1]);
-                    // expect(nodes['0'].childKeysCached).toBe(true);
-                }
+                const path = getPath(nodesBefore, '2');
+                expect(path).toEqual([1]);
 
                 const patches = [
                     {op: 'remove', path: [0]}
                 ];
 
-                const [newNodes] = produceNodePatches(nodes, newNodeCreator, value, patches);
-
-                // expect(newNodes['0'].childKeysCached).toBe(false);
+                const [newNodes] = produceNodePatches(nodesBefore, newNodeCreator, value, patches);
 
                 const path2 = getPath(newNodes, '2');
                 expect(path2).toEqual([0]);
-
-                // expect(newNodes['0'].childKeysCached).toBe(true);
             });
         });
 
@@ -664,8 +699,9 @@ describe(`Nodes`, () => {
                 const value = [1];
                 const [nodes, newNodeCreator] = createNodesFrom(value);
 
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, []);
-                const nodesBefore = nodes;
+                const nodesBefore = premakeChildNodes
+                    ? produceNodeByPath(nodes, newNodeCreator, value, [])[0]
+                    : nodes;
 
                 const patches = [
                     {op: 'replace', path: [], value: [2]}
@@ -674,7 +710,7 @@ describe(`Nodes`, () => {
                 const newValue = applyPatches(value, patches);
                 expect(newValue).toEqual([2]);
 
-                const [newNodes] = produceNodePatches(nodes, newNodeCreator, value, patches);
+                const [newNodes] = produceNodePatches(nodesBefore, newNodeCreator, value, patches);
 
                 expect(newNodes).toEqual(nodesBefore);
             });
@@ -683,8 +719,9 @@ describe(`Nodes`, () => {
                 const value = {foo: true};
                 const [nodes, newNodeCreator] = createNodesFrom(value);
 
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, []);
-                premakeChildNodes && getNodeByPath(nodes, newNodeCreator, value, ['foo']);
+                const nodesBefore = premakeChildNodes
+                    ? produceNodeByPath(nodes, newNodeCreator, value, ['foo'])[0]
+                    : nodes;
 
                 const patches = [
                     {op: 'replace', path: [], value: 9}
@@ -693,7 +730,7 @@ describe(`Nodes`, () => {
                 const newValue = applyPatches(value, patches);
                 expect(newValue).toEqual(9);
 
-                const [newNodes] = produceNodePatches(nodes, newNodeCreator, value, patches);
+                const [newNodes] = produceNodePatches(nodesBefore, newNodeCreator, value, patches);
 
                 expect(newNodes).toEqual({
                     ['0']: {

--- a/packages/dendriform/test/array.test.ts
+++ b/packages/dendriform/test/array.test.ts
@@ -50,6 +50,7 @@ describe(`array`, () => {
                 ]
             });
 
+            form.branchAll('foo');
             form.branch('foo').set(array.unshift({name: 'd'}));
 
             expect(form.value).toEqual({
@@ -91,6 +92,7 @@ describe(`array`, () => {
         test(`with Dendriform`, () => {
             const form = new Dendriform(['a','b','c']);
 
+            form.branchAll();
             form.set(array.push('d'));
 
             expect(form.value).toEqual(['a','b','c','d']);
@@ -125,6 +127,7 @@ describe(`array`, () => {
         test(`with Dendriform`, () => {
             const form = new Dendriform(['a','b','c']);
 
+            form.branchAll();
             form.set(array.pop());
 
             expect(form.value).toEqual(['a','b']);
@@ -156,6 +159,7 @@ describe(`array`, () => {
         test(`with Dendriform`, () => {
             const form = new Dendriform(['a','b','c']);
 
+            form.branchAll();
             form.set(array.shift());
 
             expect(form.value).toEqual(['b','c']);
@@ -253,6 +257,7 @@ describe(`array`, () => {
             expect(form.branch(2).id).toBe('3');
             expect(form.branch(3).id).toBe('4');
 
+            form.branchAll();
             form.set(array.move(3,1));
 
             expect(form.value).toEqual(['a','d','b','c']);


### PR DESCRIPTION
- Add validation example #15 - as yet it is not genericised, but will be for the plugin #18 
- Added descriptions #28

## Nodes
- Stop mutating child nodes #23 
- Child nodes are always created upon attempted access, regardless of the existence of the chilren in the underlying data
- Child nodes are not batch created upon parent access anymore, they are _only_ created when the children themselves have attempted access
- Changed expected behaviour - now if an object, map or basic type is removed, its node data and therefore information about its children is retained, not removed, so the user doesnt have to think about the depth of the change they are making (which is trickier to conceptualise with immer in the picture too). Arrays node data is removed as usual, because the dendriform-immer-patch-optimiser attempts to deal with child identification on arrays
- Fixed bug where new nodes were needlessly created because immer sends an "add" instead of a "replace" referring to a path that already has a value on it. Unsure whether this is an immer issue or a dendriform one. This case is easily bandaided for now.