### PR TITLE
fix: allow access of not found deep forms

### DIFF
--- a/packages/dendriform/src/Dendriform.tsx
+++ b/packages/dendriform/src/Dendriform.tsx
@@ -147,8 +147,7 @@ class Core<C> {
         history: (_id) => this.historyState
     };
 
-    createForm = (node: NodeAny): Dendriform<unknown,C> => {
-        const {id} = node;
+    createForm = (id: string): Dendriform<unknown,C> => {
         const __branch = {core: this, id};
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const form = new Dendriform<any>({__branch});
@@ -164,8 +163,8 @@ class Core<C> {
             node = isDraft(found) ? original(found) : found;
         });
 
-        if(!node) die(1, path);
-        return this.dendriforms.get(node.id) || this.createForm(node);
+        const id = node ? node.id : 'notfound';
+        return this.dendriforms.get(id) || this.createForm(id);
     };
 
     //

--- a/packages/dendriform/src/errors.ts
+++ b/packages/dendriform/src/errors.ts
@@ -1,6 +1,6 @@
 const errors = {
     0: (id: number) => `Cannot find path of node ${id}`,
-    1: (path: unknown[]) => `Cannot find node at path ${path.map(a => JSON.stringify(a)).join('","')}`,
+    // 1: (path: unknown[]) => `Cannot find node at path ${path.map(a => JSON.stringify(a)).join('","')}`,
     2: 'branchAll() can only be called on forms containing arrays',
     3: 'renderAll() can only be called on forms containing arrays',
     4: (path: unknown[]) => `useIndex() can only be called on array element forms, can't be called at path ${path.map(a => JSON.stringify(a)).join('","')}`,

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -606,6 +606,17 @@ describe(`Dendriform`, () => {
                 }
             });
         });
+
+        test(`should get impossible child value`, () => {
+            const form = new Dendriform(123);
+
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-expect-error
+            const barForm = form.branch(['foo','bar']);
+
+            expect(barForm.value).toBe(undefined);
+            expect(barForm.id).toBe('notfound');
+        });
     });
 
     describe(`.branchAll()`, () => {

--- a/packages/dendriform/test/errors.test.ts
+++ b/packages/dendriform/test/errors.test.ts
@@ -3,7 +3,7 @@ import {die} from '../src/index';
 describe(`die`, () => {
     test(`should throw errors`, () => {
         expect(() => die(0, 123)).toThrow(`[Dendriform] Cannot find path of node 123`);
-        expect(() => die(1, ['a',1])).toThrow(`[Dendriform] Cannot find node at path ["a",1]`);
+        // expect(() => die(1, ['a',1])).toThrow(`[Dendriform] Cannot find node at path ["a",1]`);
         expect(() => die(2)).toThrow(`[Dendriform] branchAll() can only be called on forms containing arrays`);
         expect(() => die(3)).toThrow(`[Dendriform] renderAll() can only be called on forms containing arrays`);
         expect(() => die(4, ['foo'])).toThrow(`[Dendriform] useIndex() can only be called on array element forms, can't be called at path [\"foo\"]`);


### PR DESCRIPTION
Fix situation where a parent data type is replaced with a simple type (e.g. undefined), but the order or updates of `useValue()` hooks means that a React component tries to render a deep value that no longer exists.