### PR TITLE
fix: deep type setting

### DIFF
--- a/packages/dendriform/src/Nodes.ts
+++ b/packages/dendriform/src/Nodes.ts
@@ -137,7 +137,13 @@ export const updateNode = (nodes: Nodes, id: string, value: unknown): void => {
     if(!node) return;
 
     const type = getType(value);
-    if(type !== ARRAY && type === node.type) return;
+    if(type !== ARRAY && type === node.type) {
+        if(type === BASIC) return;
+        each(node.child, (childId, childKey) => {
+            updateNode(nodes, childId as string, get(value, childKey));
+        });
+        return;
+    }
 
     removeNode(nodes, id, true);
     nodes[id] = {

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -574,6 +574,19 @@ describe(`Dendriform`, () => {
             expect(update.mock.calls[0][0]).toBe(2);
             expect(form.value).toEqual(['X']);
         });
+
+        test(`should update node type when switching a child to a parent`, () => {
+            const form = new Dendriform<any>({foo: true});
+
+            expect(form.branch('foo').value).toBe(true);
+
+            form.set({foo: {bar: true}});
+
+            expect(form.value).toEqual({foo: {bar: true}});
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-expect-error
+            expect(form.branch('foo').branch('bar').value).toBe(true);
+        });
     });
 
     describe(`.branch() deep`, () => {

--- a/packages/dendriform/test/Nodes.test.ts
+++ b/packages/dendriform/test/Nodes.test.ts
@@ -461,6 +461,28 @@ describe(`Nodes`, () => {
             });
         });
 
+        test(`should update item and change a deeper paths type from basic to object`, () => {
+            const value = {foo: true};
+            const [nodes, newNodeCreator] = createNodesFrom(value);
+            // create child nodes first
+            const [newNodes] = produceNodeByPath(nodes, newNodeCreator, value, ['foo']);
+            expect(newNodes['1']).toEqual({
+                type: BASIC,
+                child: undefined,
+                parentId: '0',
+                id: '1'
+            });
+            // run test
+            const newNodes2 = produce(newNodes, draft => updateNode(draft, '0', {foo: {bar: {baz: true}}}));
+            // internal child check
+            expect(newNodes2['1']).toEqual({
+                type: OBJECT,
+                child: {},
+                parentId: '0',
+                id: '1'
+            });
+        });
+
         test(`should do nothing if node doesnt exist`, () => {
             const value = ['a','b','c'];
             const [nodes, newNodeCreator] = createNodesFrom(value);


### PR DESCRIPTION
Setting a type containing deep children who change types was not working because the types of these deep children were not re-evaluated.