### PR TITLE
Nodes improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,14 +499,18 @@ function MyComponent(props) {
 }
 ```
 
-The `.set()` function can also be debounced by passing a number of milliseconds as the second argument to `.set()`.
+The `.set()` function can also accept an options object as the second argument which can affect how the set is executed.
+
+#### options.debounce
+
+The `.set()` action can be debounced by passing a number of milliseconds.
 
 ```js
 function MyComponent(props) {
     const form = useDendriform(0);
 
     const countUpDebounced = useCallback(() => {
-        form.set(count => count + 1, 100);
+        form.set(count => count + 1, {debounce: 100});
     }, []);
 
     return <div>

--- a/README.md
+++ b/README.md
@@ -524,6 +524,33 @@ function MyComponent(props) {
 }
 ```
 
+#### options.track (advanced users)
+
+Dendriform automatically assigns a unique id to every nested property and array element of the data shape it contains. It uses these ids to track the movement of array elements over time, and uniquely keys any rendered React elements. By default a call to `.set()` will analyse the resulting data shape and track how any array elements may have moved by identifying each element with strict equality checks.
+
+However you may want to disable this tracking temporarily, for example if you want to replace an array with another whose elements maybe be equal by value but are not strictly equal. This can occur sometimes when setting a form's value based on props that have not been memoised properly.
+
+```js
+const form = new Dendriform([{foo: 123}, {foo: 456}]);
+
+// form.branch(0).id is '1'
+// form.branch(1).id is '2'
+
+form.set([{foo: 123}, {foo: 456}]);
+// ^ these 2 new objects are not recognised as they are not strictly equal
+// to the previous objects, so these will be given new ids
+
+// form.branch(0).id is '3'
+// form.branch(1).id is '4'
+
+form.set([{foo: 123}, {foo: 456}], {track: false});
+// ^ with track: false, Dendriform will not attempt to track array element movement
+// so the ids for each element will remain as they are
+
+// form.branch(0).id is '3'
+// form.branch(1).id is '4'
+```
+
 #### Buffering
 
 To call it multiple times in a row, use `buffer()` to begin buffering changes and `done()` to apply the changes. These will affect the entire form including all branches, so `form.buffer()` has the same effect as `form.branch('example').buffer()`.

--- a/packages/dendriform-demo/components/Demos.tsx
+++ b/packages/dendriform-demo/components/Demos.tsx
@@ -461,11 +461,11 @@ function SettingDataDebounce(): React.ReactElement {
     });
 
     const changeA = useCallback(() => {
-        form.branch('a').set(Math.floor(Math.random() * 1000), 300);
+        form.branch('a').set(Math.floor(Math.random() * 1000), {debounce: 300});
     }, []);
 
     const changeB = useCallback(() => {
-        form.branch('b').set(Math.floor(Math.random() * 1000), 300);
+        form.branch('b').set(Math.floor(Math.random() * 1000), {debounce: 300});
     }, []);
 
     return <Region>
@@ -485,11 +485,11 @@ function MyComponent(props) {
     });
 
     const changeA = useCallback(() => {
-        form.branch('a').set(Math.floor(Math.random() * 1000), 300);
+        form.branch('a').set(Math.floor(Math.random() * 1000), {debounce: 300});
     }, []);
 
     const changeB = useCallback(() => {
-        form.branch('b').set(Math.floor(Math.random() * 1000), 300);
+        form.branch('b').set(Math.floor(Math.random() * 1000), {debounce: 300});
     }, []);
 
     return <div>

--- a/packages/dendriform/.size-limit.js
+++ b/packages/dendriform/.size-limit.js
@@ -16,7 +16,7 @@ module.exports = [
         name: 'Dendriform',
         path: "dist/dendriform.esm.js",
         import: "{ Dendriform }",
-        limit: "7.8 KB",
+        limit: "7.9 KB",
         ignore: ['react', 'react-dom']
     },
     {

--- a/packages/dendriform/README.md
+++ b/packages/dendriform/README.md
@@ -499,14 +499,18 @@ function MyComponent(props) {
 }
 ```
 
-The `.set()` function can also be debounced by passing a number of milliseconds as the second argument to `.set()`.
+The `.set()` function can also accept an options object as the second argument which can affect how the set is executed.
+
+#### options.debounce
+
+The `.set()` action can be debounced by passing a number of milliseconds.
 
 ```js
 function MyComponent(props) {
     const form = useDendriform(0);
 
     const countUpDebounced = useCallback(() => {
-        form.set(count => count + 1, 100);
+        form.set(count => count + 1, {debounce: 100});
     }, []);
 
     return <div>

--- a/packages/dendriform/README.md
+++ b/packages/dendriform/README.md
@@ -524,6 +524,33 @@ function MyComponent(props) {
 }
 ```
 
+#### options.track (advanced users)
+
+Dendriform automatically assigns a unique id to every nested property and array element of the data shape it contains. It uses these ids to track the movement of array elements over time, and uniquely keys any rendered React elements. By default a call to `.set()` will analyse the resulting data shape and track how any array elements may have moved by identifying each element with strict equality checks.
+
+However you may want to disable this tracking temporarily, for example if you want to replace an array with another whose elements maybe be equal by value but are not strictly equal. This can occur sometimes when setting a form's value based on props that have not been memoised properly.
+
+```js
+const form = new Dendriform([{foo: 123}, {foo: 456}]);
+
+// form.branch(0).id is '1'
+// form.branch(1).id is '2'
+
+form.set([{foo: 123}, {foo: 456}]);
+// ^ these 2 new objects are not recognised as they are not strictly equal
+// to the previous objects, so these will be given new ids
+
+// form.branch(0).id is '3'
+// form.branch(1).id is '4'
+
+form.set([{foo: 123}, {foo: 456}], {track: false});
+// ^ with track: false, Dendriform will not attempt to track array element movement
+// so the ids for each element will remain as they are
+
+// form.branch(0).id is '3'
+// form.branch(1).id is '4'
+```
+
 #### Buffering
 
 To call it multiple times in a row, use `buffer()` to begin buffering changes and `done()` to apply the changes. These will affect the entire form including all branches, so `form.buffer()` has the same effect as `form.branch('example').buffer()`.

--- a/packages/dendriform/src/Dendriform.tsx
+++ b/packages/dendriform/src/Dendriform.tsx
@@ -175,8 +175,9 @@ class Core<C> {
 
     debounceMap = new Map<string,number>();
 
-    setWithDebounce = (id: string, toProduce: unknown, debounce = 0): void => {
-        if(debounce === 0) {
+    setWithDebounce = (id: string, toProduce: unknown, options: SetOptions): void => {
+        const {debounce} = options;
+        if(!debounce) {
             this.set(id, toProduce);
             return;
         }
@@ -469,22 +470,26 @@ const Branch = React.memo(
 // (wrapper around core)
 //
 
-type DendriformBranch = {
+export type DendriformBranch = {
     __branch: {
         core: Core<unknown>;
         id: string;
     };
 };
 
-type Renderer<D> = (form: D) => MaybeReactElement;
+export type Renderer<D> = (form: D) => MaybeReactElement;
 
-type ChildToProduce<V> = (key: PropertyKey) => ToProduce<V>;
+export type ChildToProduce<V> = (key: PropertyKey) => ToProduce<V>;
 
-type KeyMap<M extends Map<unknown, unknown>> = M extends Map<infer K, unknown> ? K : never;
-type ValMap<A> = A extends Map<unknown, infer V> ? V : never;
+export type KeyMap<M extends Map<unknown, unknown>> = M extends Map<infer K, unknown> ? K : never;
+export type ValMap<A> = A extends Map<unknown, infer V> ? V : never;
 
-type Key<V> = V extends Map<unknown, unknown> ? KeyMap<V> : keyof V;
-type Val<V,K> = V extends Map<unknown, unknown> ? ValMap<V> : K extends keyof V ? V[K] : never;
+export type Key<V> = V extends Map<unknown, unknown> ? KeyMap<V> : keyof V;
+export type Val<V,K> = V extends Map<unknown, unknown> ? ValMap<V> : K extends keyof V ? V[K] : never;
+
+export type SetOptions = {
+    debounce?: number;
+};
 
 export class Dendriform<V> {
 
@@ -531,14 +536,14 @@ export class Dendriform<V> {
         return this.core.historyState;
     }
 
-    set = (toProduce: ToProduce<V>, debounce = 0): void => {
-        this.core.setWithDebounce(this.id, toProduce, debounce);
+    set = (toProduce: ToProduce<V>, options: SetOptions = {}): void => {
+        this.core.setWithDebounce(this.id, toProduce, options);
     };
 
-    setParent = (childToProduce: ChildToProduce<unknown>, debounce = 0): void => {
+    setParent = (childToProduce: ChildToProduce<unknown>, options: SetOptions = {}): void => {
         const basePath = this.core.getPathOrError(this.id);
         const parent = this.core.getFormAt(basePath.slice(0,-1));
-        this.core.setWithDebounce(parent.id, childToProduce(basePath[basePath.length - 1]), debounce);
+        this.core.setWithDebounce(parent.id, childToProduce(basePath[basePath.length - 1]), options);
     };
 
     onChange(callback: ChangeCallback<number>, changeType: ChangeTypeIndex): (() => void);

--- a/packages/dendriform/src/Dendriform.tsx
+++ b/packages/dendriform/src/Dendriform.tsx
@@ -178,13 +178,13 @@ class Core<C> {
     setWithDebounce = (id: string, toProduce: unknown, options: SetOptions): void => {
         const {debounce} = options;
         if(!debounce) {
-            this.set(id, toProduce);
+            this.set(id, toProduce, options);
             return;
         }
 
         const countAtCall = (this.debounceMap.get(id) ?? 0) + 1;
         this.debounceMap.set(id, countAtCall);
-        setTimeout(() => countAtCall === this.debounceMap.get(id) && this.set(id, toProduce), debounce);
+        setTimeout(() => countAtCall === this.debounceMap.get(id) && this.set(id, toProduce, options), debounce);
     };
 
     // if setBuffer exists, then new changes will be merged onto it
@@ -193,12 +193,12 @@ class Core<C> {
     setBuffer?: HistoryPatch;
     replaceByDefault = false;
 
-    set = (id: string, toProduce: unknown): void => {
+    set = (id: string, toProduce: unknown, options: SetOptions): void => {
         const path = this.getPath(id);
         if(!path) return;
 
         // produce patches that describe the change
-        const [, valuePatches, valuePatchesInv] = producePatches(this.getValue(id), toProduce);
+        const [, valuePatches, valuePatchesInv] = producePatches(this.getValue(id), toProduce, options.track);
 
         // transform patches so they have absolute paths
         const valuePatchesZoomed = zoomOutPatches(path, valuePatches);
@@ -489,6 +489,7 @@ export type Val<V,K> = V extends Map<unknown, unknown> ? ValMap<V> : K extends k
 
 export type SetOptions = {
     debounce?: number;
+    track?: boolean;
 };
 
 export class Dendriform<V> {

--- a/packages/dendriform/src/Nodes.ts
+++ b/packages/dendriform/src/Nodes.ts
@@ -137,7 +137,7 @@ export const updateNode = (nodes: Nodes, id: string, value: unknown): void => {
     if(!node) return;
 
     const type = getType(value);
-    if(type !== ARRAY && type === node.type) {
+    if(type === node.type) {
         if(type === BASIC) return;
         each(node.child, (childId, childKey) => {
             if(has(value, childKey)) {

--- a/packages/dendriform/src/Nodes.ts
+++ b/packages/dendriform/src/Nodes.ts
@@ -1,4 +1,4 @@
-import {BASIC, OBJECT, ARRAY, MAP, getType, get, set, each, create, applyPatches} from 'dendriform-immer-patch-optimiser';
+import {BASIC, OBJECT, ARRAY, MAP, getType, has, get, set, each, create, applyPatches} from 'dendriform-immer-patch-optimiser';
 import type {Path, DendriformPatch} from 'dendriform-immer-patch-optimiser';
 import {produceWithPatches} from 'immer';
 
@@ -140,7 +140,13 @@ export const updateNode = (nodes: Nodes, id: string, value: unknown): void => {
     if(type !== ARRAY && type === node.type) {
         if(type === BASIC) return;
         each(node.child, (childId, childKey) => {
-            updateNode(nodes, childId as string, get(value, childKey));
+            if(has(value, childKey)) {
+                updateNode(nodes, childId as string, get(value, childKey));
+            } else {
+                removeNode(nodes, childId as string);
+                // @ts-ignore
+                delete node.child[childKey];
+            }
         });
         return;
     }

--- a/packages/dendriform/src/Nodes.ts
+++ b/packages/dendriform/src/Nodes.ts
@@ -144,6 +144,7 @@ export const updateNode = (nodes: Nodes, id: string, value: unknown): void => {
                 updateNode(nodes, childId as string, get(value, childKey));
             } else {
                 removeNode(nodes, childId as string);
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore
                 delete node.child[childKey];
             }

--- a/packages/dendriform/src/producePatches.ts
+++ b/packages/dendriform/src/producePatches.ts
@@ -38,7 +38,7 @@ export const patches = <V,>(patches: DendriformPatch[]|PatchCreator<V>, patchesI
 
 export const noChange = patches([], []);
 
-export const producePatches = <V>(base: V, toProduce: ToProduce<V>): [V, DendriformPatch[], DendriformPatch[]] => {
+export const producePatches = <V>(base: V, toProduce: ToProduce<V>, track: boolean = true): [V, DendriformPatch[], DendriformPatch[]] => {
     if(isPatchPair(toProduce)) {
         const patches = toProduce.__patches(base);
         const patchesInverse = toProduce.__patchesInverse(base);
@@ -61,10 +61,10 @@ export const producePatches = <V>(base: V, toProduce: ToProduce<V>): [V, Dendrif
     return [
         newValue as V,
         patches
-            ? optimise(base, patches)
+            ? (track ? optimise(base, patches) : patches)
             : [{op: 'replace', path: [], value: newValue}],
         inversePatches
-            ? optimise(newValue, inversePatches)
+            ? (track ? optimise(newValue, inversePatches) : inversePatches)
             : [{op: 'replace', path: [], value: base}]
     ];
 };

--- a/packages/dendriform/src/producePatches.ts
+++ b/packages/dendriform/src/producePatches.ts
@@ -38,7 +38,7 @@ export const patches = <V,>(patches: DendriformPatch[]|PatchCreator<V>, patchesI
 
 export const noChange = patches([], []);
 
-export const producePatches = <V>(base: V, toProduce: ToProduce<V>, track: boolean = true): [V, DendriformPatch[], DendriformPatch[]] => {
+export const producePatches = <V>(base: V, toProduce: ToProduce<V>, track = true): [V, DendriformPatch[], DendriformPatch[]] => {
     if(isPatchPair(toProduce)) {
         const patches = toProduce.__patches(base);
         const patchesInverse = toProduce.__patchesInverse(base);

--- a/packages/dendriform/src/useInput.ts
+++ b/packages/dendriform/src/useInput.ts
@@ -19,7 +19,7 @@ export const useInput = <V extends string|null|undefined>(form: Dendriform<V>, d
     const onChange = useCallback(event => {
         const newValue = event.target.value;
         setLocalValue(newValue);
-        form.set(newValue, debounce);
+        form.set(newValue, {debounce});
     }, []);
 
     return {

--- a/packages/dendriform/src/useProps.ts
+++ b/packages/dendriform/src/useProps.ts
@@ -18,7 +18,7 @@ export const useProps = <V>(form: Dendriform<V>, debounce = 0): UsePropsResult<V
 
     const onChange = useCallback((newValue: V) => {
         setLocalValue(newValue);
-        form.set(newValue, debounce);
+        form.set(newValue, {debounce});
     }, []);
 
     return {

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -1,5 +1,6 @@
 import {useDendriform, Dendriform, noChange, sync, useSync, immerable} from '../src/index';
 import {renderHook, act} from '@testing-library/react-hooks';
+import {BASIC, OBJECT, ARRAY} from 'dendriform-immer-patch-optimiser';
 
 import React from 'react';
 import Enzyme, {mount} from 'enzyme';
@@ -2212,5 +2213,438 @@ describe(`Dendriform`, () => {
                 expect(slaveForm.value).toBe(12);
             });
         });
+    });
+
+    describe(`nodes behaviour`, () => {
+
+        test(`should add nodes as data is traversed`, () => {
+            const form = new Dendriform({
+                foo: {
+                    bar: 123,
+                    baz: 456
+                }
+            });
+
+
+            expect(form.core.nodes).toEqual({
+                '0': {
+                    child: {},
+                    id: '0',
+                    parentId: '',
+                    type: OBJECT
+                }
+            });
+
+            form.branch('foo');
+
+            expect(form.core.nodes).toEqual({
+                '0': {
+                    child: {
+                        foo: '1'
+                    },
+                    id: '0',
+                    parentId: '',
+                    type: OBJECT
+                },
+                '1': {
+                    child: {},
+                    id: '1',
+                    parentId: '0',
+                    type: OBJECT
+                }
+            });
+
+            form.branch(['foo','bar']);
+
+            expect(form.core.nodes).toEqual({
+                '0': {
+                    child: {
+                        foo: '1'
+                    },
+                    id: '0',
+                    parentId: '',
+                    type: OBJECT
+                },
+                '1': {
+                    child: {
+                        bar: '2'
+                    },
+                    id: '1',
+                    parentId: '0',
+                    type: OBJECT
+                },
+                '2': {
+                    id: '2',
+                    parentId: '1',
+                    type: BASIC
+                }
+            });
+        });
+
+        test(`should remove nodes as data is deleted (no changed types)`, () => {
+            const form = new Dendriform<any>({
+                foo: {
+                    bar: 123,
+                    baz: 456
+                }
+            });
+
+            form.branch(['foo','bar']);
+
+            expect(form.core.nodes).toEqual({
+                '0': {
+                    child: {
+                        foo: '1'
+                    },
+                    id: '0',
+                    parentId: '',
+                    type: OBJECT
+                },
+                '1': {
+                    child: {
+                        bar: '2'
+                    },
+                    id: '1',
+                    parentId: '0',
+                    type: OBJECT
+                },
+                '2': {
+                    id: '2',
+                    parentId: '1',
+                    type: BASIC
+                }
+            });
+
+            form.branch('foo').set({});
+
+            expect(form.core.nodes).toEqual({
+                '0': {
+                    child: {
+                        foo: '1'
+                    },
+                    id: '0',
+                    parentId: '',
+                    type: OBJECT
+                },
+                '1': {
+                    child: {},
+                    id: '1',
+                    parentId: '0',
+                    type: OBJECT
+                }
+            });
+        });
+
+         test(`should remove nodes as parent changes type`, () => {
+            const form = new Dendriform<any>({
+                foo: {
+                    bar: 123,
+                    baz: 456
+                }
+            });
+
+            form.branch(['foo','bar']);
+
+            expect(form.core.nodes).toEqual({
+                '0': {
+                    child: {
+                        foo: '1'
+                    },
+                    id: '0',
+                    parentId: '',
+                    type: OBJECT
+                },
+                '1': {
+                    child: {
+                        bar: '2'
+                    },
+                    id: '1',
+                    parentId: '0',
+                    type: OBJECT
+                },
+                '2': {
+                    id: '2',
+                    parentId: '1',
+                    type: BASIC
+                }
+            });
+
+            form.branch('foo').set([]);
+
+            expect(form.core.nodes).toEqual({
+                '0': {
+                    child: {
+                        foo: '1'
+                    },
+                    id: '0',
+                    parentId: '',
+                    type: OBJECT
+                },
+                '1': {
+                    child: [],
+                    id: '1',
+                    parentId: '0',
+                    type: ARRAY
+                }
+            });
+        });
+
+        test(`should retain common nodes when data is replaced`, () => {
+            const form = new Dendriform<any>({
+                foo: {
+                    bar: 123,
+                    baz: 456
+                }
+            });
+
+            form.branch(['foo','bar']);
+            form.branch(['foo','baz']);
+
+            expect(form.core.nodes).toEqual({
+                '0': {
+                    child: {
+                        foo: '1'
+                    },
+                    id: '0',
+                    parentId: '',
+                    type: OBJECT
+                },
+                '1': {
+                    child: {
+                        bar: '2',
+                        baz: '3'
+                    },
+                    id: '1',
+                    parentId: '0',
+                    type: OBJECT
+                },
+                '2': {
+                    id: '2',
+                    parentId: '1',
+                    type: BASIC
+                },
+                '3': {
+                    id: '3',
+                    parentId: '1',
+                    type: BASIC
+                }
+            });
+
+            form.set({
+                foo: {
+                    bar: 123
+                }
+            });
+
+            expect(form.core.nodes).toEqual({
+                '0': {
+                    child: {
+                        foo: '1'
+                    },
+                    id: '0',
+                    parentId: '',
+                    type: OBJECT
+                },
+                '1': {
+                    child: {
+                        bar: '2'
+                    },
+                    id: '1',
+                    parentId: '0',
+                    type: OBJECT
+                },
+                '2': {
+                    id: '2',
+                    parentId: '1',
+                    type: BASIC
+                }
+            });
+        });
+
+        test(`should retain nothing when data is replaced at source`, () => {
+            const form = new Dendriform<any>({
+                foo: {
+                    bar: 123,
+                    baz: 456
+                }
+            });
+
+            form.branch(['foo','bar']);
+            form.branch(['foo','baz']);
+
+            expect(form.core.nodes).toEqual({
+                '0': {
+                    child: {
+                        foo: '1'
+                    },
+                    id: '0',
+                    parentId: '',
+                    type: OBJECT
+                },
+                '1': {
+                    child: {
+                        bar: '2',
+                        baz: '3'
+                    },
+                    id: '1',
+                    parentId: '0',
+                    type: OBJECT
+                },
+                '2': {
+                    id: '2',
+                    parentId: '1',
+                    type: BASIC
+                },
+                '3': {
+                    id: '3',
+                    parentId: '1',
+                    type: BASIC
+                }
+            });
+
+            form.set({});
+
+            expect(form.core.nodes).toEqual({
+                '0': {
+                    child: {},
+                    id: '0',
+                    parentId: '',
+                    type: OBJECT
+                }
+            });
+        });
+
+        test(`should retain common nodes when data is replaced on array`, () => {
+            const form = new Dendriform<any>([123, 456, 789]);
+
+            form.branch(2);
+            form.branch(1);
+            form.branch(0);
+
+            expect(form.core.nodes).toEqual({
+                '0': {
+                    child: ['3','2','1'],
+                    id: '0',
+                    parentId: '',
+                    type: ARRAY
+                },
+                '1': {
+                    id: '1',
+                    parentId: '0',
+                    type: BASIC
+                },
+                '2': {
+                    id: '2',
+                    parentId: '0',
+                    type: BASIC
+                },
+                '3': {
+                    id: '3',
+                    parentId: '0',
+                    type: BASIC
+                }
+            });
+
+            form.set([123, 456]);
+
+            expect(form.core.nodes).toEqual({
+                '0': {
+                    child: ['3','2'],
+                    id: '0',
+                    parentId: '',
+                    type: ARRAY
+                },
+                '2': {
+                    id: '2',
+                    parentId: '0',
+                    type: BASIC
+                },
+                '3': {
+                    id: '3',
+                    parentId: '0',
+                    type: BASIC
+                }
+            });
+        });
+
+        test.only(`should retain common nodes when data is replaced on array containing objects`, () => {
+            const form = new Dendriform<any>([{foo: 123}, {foo: 456}]);
+
+            form.branch([0,'foo']);
+            form.branch([1,'foo']);
+
+            expect(form.core.nodes).toEqual({
+                '0': {
+                    child: ['1','3'],
+                    id: '0',
+                    parentId: '',
+                    type: ARRAY
+                },
+                '1': {
+                    id: '1',
+                    child: {
+                        foo: '2'
+                    },
+                    parentId: '0',
+                    type: OBJECT
+                },
+                '2': {
+                    id: '2',
+                    parentId: '1',
+                    type: BASIC
+                },
+                '3': {
+                    id: '3',
+                    child: {
+                        foo: '4'
+                    },
+                    parentId: '0',
+                    type: OBJECT
+                },
+                '4': {
+                    id: '4',
+                    parentId: '3',
+                    type: BASIC
+                }
+            });
+
+            form.set([{foo: 123}, {foo: 456}]);
+
+            expect(form.core.nodes).toEqual({
+                '0': {
+                    child: ['1','3'],
+                    id: '0',
+                    parentId: '',
+                    type: ARRAY
+                },
+                '1': {
+                    id: '1',
+                    child: {
+                        foo: '2'
+                    },
+                    parentId: '0',
+                    type: OBJECT
+                },
+                '2': {
+                    id: '2',
+                    parentId: '1',
+                    type: BASIC
+                },
+                '3': {
+                    id: '3',
+                    child: {
+                        foo: '4'
+                    },
+                    parentId: '0',
+                    type: OBJECT
+                },
+                '4': {
+                    id: '4',
+                    parentId: '3',
+                    type: BASIC
+                }
+            });
+        });
+
     });
 });

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -76,11 +76,11 @@ describe(`Dendriform`, () => {
         test(`should set value with debounce`, () => {
             const form = new Dendriform(123);
 
-            form.set(456, 100);
+            form.set(456, {debounce: 100});
             jest.advanceTimersByTime(80);
             expect(form.value).toBe(123);
 
-            form.set(789, 100);
+            form.set(789, {debounce: 100});
             jest.advanceTimersByTime(80);
             expect(form.value).toBe(123);
 
@@ -2567,7 +2567,7 @@ describe(`Dendriform`, () => {
             });
         });
 
-        test.only(`should retain common nodes when data is replaced on array containing objects`, () => {
+        test(`should retain common nodes when data is replaced on array containing objects`, () => {
             const form = new Dendriform<any>([{foo: 123}, {foo: 456}]);
 
             form.branch([0,'foo']);
@@ -2608,7 +2608,7 @@ describe(`Dendriform`, () => {
                 }
             });
 
-            form.set([{foo: 123}, {foo: 456}]);
+            form.set([{foo: 123}, {foo: 456}], {track: false});
 
             expect(form.core.nodes).toEqual({
                 '0': {

--- a/packages/dendriform/test/Nodes.test.ts
+++ b/packages/dendriform/test/Nodes.test.ts
@@ -371,34 +371,6 @@ describe(`Nodes`, () => {
 
     describe(`updateNode()`, () => {
 
-        test(`should remove and update nodes if type is the same and is an array`, () => {
-            // because arrays children are identified by their indexes which can and do move.
-            // the dendriform-immer-patch-optimiser will normally take care of those movements if they
-            // take place at the depth of the array within the value data shape,
-            // but if not then we have to remove the array element's nodes to be careful
-            // and prevent those elements from possibly beging adopted by other children
-            const value = [100];
-            const [nodes, newNodeCreator] = createNodesFrom(value);
-            // create child nodes first
-            const [newNodes] = produceNodeByPath(nodes, newNodeCreator, value, [0]);
-            expect(newNodes['0']).toEqual({
-                type: ARRAY,
-                child: ['1'],
-                parentId: '',
-                id: '0'
-            });
-
-            // run test
-            const newNodes2 = produce(newNodes, draft => updateNode(draft, '0', [300]));
-            // node should have been updated
-            expect(newNodes2['0']).toEqual({
-                type: ARRAY,
-                child: [],
-                parentId: '',
-                id: '0'
-            });
-        });
-
         test(`should update item and change its type from basic to object`, () => {
             const value = ['a','b','c'];
             const [nodes, newNodeCreator] = createNodesFrom(value);

--- a/packages/dendriform/test/Nodes.test.ts
+++ b/packages/dendriform/test/Nodes.test.ts
@@ -371,34 +371,6 @@ describe(`Nodes`, () => {
 
     describe(`updateNode()`, () => {
 
-        test(`should not update nodes if type is the same and type is not an array`, () => {
-            // because non-arrays children are identified by their keys which never move
-            const value = {foo: 123};
-            const [nodes, newNodeCreator] = createNodesFrom(value);
-            // create child nodes first
-            const [newNodes] = produceNodeByPath(nodes, newNodeCreator, value, ['foo']);
-            expect(newNodes['0']).toEqual({
-                type: OBJECT,
-                child: {
-                    foo: '1'
-                },
-                parentId: '',
-                id: '0'
-            });
-
-            // run test
-            const newNodes2 = produce(newNodes, draft => updateNode(draft, '0', {bar: 456}));
-            // node 0 should still be the same
-            expect(newNodes2['0']).toEqual({
-                type: OBJECT,
-                child: {
-                    foo: '1'
-                },
-                parentId: '',
-                id: '0'
-            });
-        });
-
         test(`should remove and update nodes if type is the same and is an array`, () => {
             // because arrays children are identified by their indexes which can and do move.
             // the dendriform-immer-patch-optimiser will normally take care of those movements if they


### PR DESCRIPTION
- clean up nodes more accurately, so deletions of parts of a data shape result in deletions of nodes
  - in preparation for plugins like validation that will hold per-node metadata