### PR TITLE
Cancellable changes, es6 set support, diff changes

### DIFF
--- a/packages/dendriform-immer-patch-optimiser/.size-limit.js
+++ b/packages/dendriform-immer-patch-optimiser/.size-limit.js
@@ -2,7 +2,7 @@ module.exports = [
     {
         name: 'everything combined',
         path: "dist/dendriform-immer-patch-optimiser.esm.js",
-        limit: "1.2 KB",
+        limit: "1.3 KB",
         ignore: ['immer']
     },
     {

--- a/packages/dendriform-immer-patch-optimiser/package.json
+++ b/packages/dendriform-immer-patch-optimiser/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-alpha.4",
+  "version": "2.0.0",
   "license": "MIT",
   "main": "dist/index.js",
   "description": "Immer patch optimisation to add \"move\" operations.",

--- a/packages/dendriform-immer-patch-optimiser/src/optimise.ts
+++ b/packages/dendriform-immer-patch-optimiser/src/optimise.ts
@@ -2,7 +2,7 @@ import {applyPatches, enablePatches, nothing} from 'immer';
 import {getIn} from './traverse';
 import {zoomInPatches, zoomOutPatches} from './zoomPatches';
 import type {Patch as ImmerPatch} from 'immer';
-import type {DendriformPatch, Path} from './types';
+import type {DendriformPatch, Path, Key} from './types';
 
 enablePatches();
 
@@ -33,7 +33,7 @@ export const optimise = <B,>(base: B, patches: ImmerPatch[]): DendriformPatch[] 
 
     // check path is array (memoised)
     let lastResult: CheckPathResult|undefined;
-    const checkPathIsArray = <B,>(base: B, path: PropertyKey[]): boolean => {
+    const checkPathIsArray = <B,>(base: B, path: Key[]): boolean => {
         const pathString = JSON.stringify(path);
         if(lastResult && lastResult[1] === pathString) return lastResult[0];
         const isArray = Array.isArray(getIn(base, path));

--- a/packages/dendriform-immer-patch-optimiser/src/traverse.ts
+++ b/packages/dendriform-immer-patch-optimiser/src/traverse.ts
@@ -1,3 +1,5 @@
+import type {Key} from './types';
+
 export const BASIC = 0;
 export const OBJECT = 1;
 export const ARRAY = 2;
@@ -5,7 +7,7 @@ export const MAP = 3;
 
 export type DataType = typeof ARRAY|typeof OBJECT|typeof BASIC|typeof MAP;
 
-const cantAccess = (thing: unknown, key: PropertyKey) => new Error(`Cant access property ${String(key)} of ${String(thing)}`);
+const cantAccess = (thing: unknown, key: Key) => new Error(`Cant access property ${String(key)} of ${String(thing)}`);
 
 export function getType(thing: unknown): DataType {
     if(thing instanceof Map) return MAP;
@@ -15,7 +17,7 @@ export function getType(thing: unknown): DataType {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export function has(thing: any, key: PropertyKey): boolean {
+export function has(thing: any, key: Key): boolean {
     const type = getType(thing);
     if(type === OBJECT) {
         return key in thing;
@@ -31,7 +33,7 @@ export function has(thing: any, key: PropertyKey): boolean {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export function get(thing: any, key: PropertyKey): unknown {
+export function get(thing: any, key: Key): unknown {
     const type = getType(thing);
     if(type === BASIC) {
         throw cantAccess(thing, key);
@@ -43,12 +45,12 @@ export function get(thing: any, key: PropertyKey): unknown {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export function getIn(thing: unknown, path: PropertyKey[]): unknown {
+export function getIn(thing: unknown, path: Key[]): unknown {
     return path.reduce((red, key) => get(red, key), thing);
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export function set(thing: any, key: PropertyKey, value: unknown): void {
+export function set(thing: any, key: Key, value: unknown): void {
     const type = getType(thing);
     if(type === BASIC) {
         throw cantAccess(thing, key);
@@ -59,20 +61,14 @@ export function set(thing: any, key: PropertyKey, value: unknown): void {
     thing[key] = value;
 }
 
-export type EachCallback = (value: unknown, key: PropertyKey) => void;
+export type EachCallback = (value: unknown, key: Key) => void;
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-export function each(thing: any, callback: EachCallback): void {
+export function entries(thing: any): [Key,any][] {
     const type = getType(thing);
-    if(type === BASIC) {
-        throw cantAccess(thing, 'any');
-    }
-    if(type === OBJECT) {
-        Object.keys(thing).forEach((key: string) => callback(thing[key], key));
-    }
-    if(type === ARRAY || type === MAP) {
-        thing.forEach(callback);
-    }
+    if(type === OBJECT) return Object.entries(thing);
+    if(type === ARRAY || type === MAP) return Array.from(thing.entries());
+    throw cantAccess(thing, 'any');
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any

--- a/packages/dendriform-immer-patch-optimiser/src/types.ts
+++ b/packages/dendriform-immer-patch-optimiser/src/types.ts
@@ -1,4 +1,5 @@
-export type Path = (string|number)[];
+export type Key = number|string;
+export type Path = Key[];
 
 export type DendriformPatch = {
     namespace?: string;

--- a/packages/dendriform-immer-patch-optimiser/test/optimise.test.ts
+++ b/packages/dendriform-immer-patch-optimiser/test/optimise.test.ts
@@ -1,7 +1,9 @@
-import {produceWithPatches, nothing} from 'immer';
+import {produceWithPatches, nothing, enableMapSet} from 'immer';
 import {optimise, applyPatches} from '../src/index';
 import type {Patch as ImmerPatch} from 'immer';
 import type {DendriformPatch} from '../src/types';
+
+enableMapSet();
 
 type Expected = {
     vanilla: ImmerPatch[],
@@ -539,4 +541,59 @@ describe('immer bug fix: nothings in patches should be replaced with undefineds'
         expect(optimisedPatches[0].value).toBe(undefined);
     });
 
+});
+
+describe('immer Set patches', () => {
+
+
+    it('demonstrate immer Set patches with numbers', () => {
+        const base = new Set([0,1,2]);
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        const [result, recordedPatches] = produceWithPatches(base, draft => {
+            draft.delete(2);
+            draft.add(3);
+        });
+
+        expect(recordedPatches).toEqual([
+            {op: 'remove', path: [2], value: 2},
+            {op: 'add', path: [2], value: 3}
+        ]);
+    });
+
+    it('demonstrate immer Set patches with strings', () => {
+        const base = new Set(['a','b','c']);
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        const [result, recordedPatches] = produceWithPatches(base, draft => {
+            draft.delete('b');
+            draft.add('d');
+        });
+
+        expect(recordedPatches).toEqual([
+            {op: 'remove', path: [1], value: 'b'},
+            {op: 'add', path: [2], value: 'd'}
+        ]);
+    });
+
+    it('demonstrate immer Set patches with objects', () => {
+        const obj1 = {foo: true};
+        const obj2 = {bar: true};
+        const obj3 = {baz: true};
+        const base = new Set<{[key: string]: boolean}>([obj1, obj2]);
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        const [result, recordedPatches] = produceWithPatches(base, draft => {
+            draft.delete(obj1);
+            draft.add(obj3);
+        });
+
+        expect(recordedPatches).toEqual([
+            {op: 'remove', path: [0], value: obj1},
+            {op: 'add', path: [0], value: obj3}
+        ]);
+    });
 });

--- a/packages/dendriform-immer-patch-optimiser/test/traverse.test.ts
+++ b/packages/dendriform-immer-patch-optimiser/test/traverse.test.ts
@@ -1,4 +1,4 @@
-import {BASIC, OBJECT, ARRAY, MAP, getType, has, get, getIn, set, each, clone, create} from '../src/index';
+import {BASIC, OBJECT, ARRAY, MAP, getType, has, get, getIn, set, entries, clone, create} from '../src/index';
 
 describe(`getType`, () => {
     test(`should identify basics`, () => {
@@ -136,56 +136,33 @@ describe(`set`, () => {
 });
 
 
-describe(`each`, () => {
+describe(`entries`, () => {
     test(`should work with object`, () => {
-        const callback = jest.fn();
         const obj = {foo: 1, bar: 2};
 
-        each(obj, callback);
-
-        expect(callback).toHaveBeenCalledTimes(2);
-        expect(callback.mock.calls[0][0]).toBe(1);
-        expect(callback.mock.calls[0][1]).toBe('foo');
-        expect(callback.mock.calls[1][0]).toBe(2);
-        expect(callback.mock.calls[1][1]).toBe('bar');
+        const result = entries(obj);
+        expect(result).toEqual([['foo',1],['bar',2]]);
     });
 
     test(`should work with array`, () => {
-        const callback = jest.fn();
         const arr = ['a','b','c'];
 
-        each(arr, callback);
-
-        expect(callback).toHaveBeenCalledTimes(3);
-        expect(callback.mock.calls[0][0]).toBe('a');
-        expect(callback.mock.calls[0][1]).toBe(0);
-        expect(callback.mock.calls[1][0]).toBe('b');
-        expect(callback.mock.calls[1][1]).toBe(1);
-        expect(callback.mock.calls[2][0]).toBe('c');
-        expect(callback.mock.calls[2][1]).toBe(2);
+        const result = entries(arr);
+        expect(result).toEqual([[0,'a'],[1,'b'],[2,'c']]);
     });
 
     test(`should work with map`, () => {
-        const callback = jest.fn();
         const map = new Map([['foo', 1], ['bar', 2]]);
 
-        each(map, callback);
-
-        expect(callback).toHaveBeenCalledTimes(2);
-        expect(callback.mock.calls[0][0]).toBe(1);
-        expect(callback.mock.calls[0][1]).toBe('foo');
-        expect(callback.mock.calls[1][0]).toBe(2);
+        const result = entries(map);
+        expect(result).toEqual([['foo',1],['bar',2]]);
     });
 
     test(`should error on basic types`, () => {
-        const callback = jest.fn();
-
-        expect(() => each(100, callback)).toThrow(`Cant access property any of 100`);
-        expect(() => each("str", callback)).toThrow(`Cant access property any of str`);
-        expect(() => each(null, callback)).toThrow(`Cant access property any of null`);
-        expect(() => each(undefined, callback)).toThrow(`Cant access property any of undefined`);
-
-        expect(callback).toHaveBeenCalledTimes(0);
+        expect(() => entries(100)).toThrow(`Cant access property any of 100`);
+        expect(() => entries("str")).toThrow(`Cant access property any of str`);
+        expect(() => entries(null)).toThrow(`Cant access property any of null`);
+        expect(() => entries(undefined)).toThrow(`Cant access property any of undefined`);
     });
 });
 

--- a/packages/dendriform-immer-patch-optimiser/test/traverse.test.ts
+++ b/packages/dendriform-immer-patch-optimiser/test/traverse.test.ts
@@ -1,4 +1,4 @@
-import {BASIC, OBJECT, ARRAY, MAP, getType, has, get, getIn, set, entries, clone, create} from '../src/index';
+import {BASIC, OBJECT, ARRAY, MAP, SET, getType, has, get, getIn, set, entries, clone, create} from '../src/index';
 
 describe(`getType`, () => {
     test(`should identify basics`, () => {
@@ -21,6 +21,10 @@ describe(`getType`, () => {
 
     test(`should identify map`, () => {
         expect(getType(new Map())).toBe(MAP);
+    });
+
+    test(`should identify set`, () => {
+        expect(getType(new Set())).toBe(SET);
     });
 });
 
@@ -49,6 +53,13 @@ describe(`has`, () => {
         expect(has(map, 1)).toBe(false);
         expect(has(map, 2)).toBe(true);
     });
+
+    test(`should work with set`, () => {
+        const set = new Set<number>([0,2]);
+        expect(has(set, 0)).toBe(true);
+        expect(has(set, 1)).toBe(false);
+        expect(has(set, 2)).toBe(true);
+    });
 });
 
 describe(`get`, () => {
@@ -76,6 +87,16 @@ describe(`get`, () => {
     test(`should work with map and miss`, () => {
         const map = new Map<number,boolean>([[0,true],[2,false]]);
         expect(get(map, 1)).toBe(undefined);
+    });
+
+    test(`should work with set`, () => {
+        const set = new Set<number>([0,2]);
+        expect(get(set, 2)).toBe(2);
+    });
+
+    test(`should work with set and miss`, () => {
+        const set = new Set<number>([0,2]);
+        expect(get(set, 1)).toBe(undefined);
     });
 
     test(`should error on basic types`, () => {
@@ -127,6 +148,12 @@ describe(`set`, () => {
         expect(map.get(2)).toBe(true);
     });
 
+    test(`should work with map`, () => {
+        const s = new Set<number>([0,2]);
+        set(s, 2, 3);
+        expect(Array.from(s.values())).toEqual([0,3]);
+    });
+
     test(`should error on basic types`, () => {
         expect(() => set(100, 4, 4)).toThrow(`Cant access property 4 of 100`);
         expect(() => set("str", 4, 4)).toThrow(`Cant access property 4 of str`);
@@ -156,6 +183,13 @@ describe(`entries`, () => {
 
         const result = entries(map);
         expect(result).toEqual([['foo',1],['bar',2]]);
+    });
+
+    test(`should work with set`, () => {
+        const set = new Set(['foo','bar']);
+
+        const result = entries(set);
+        expect(result).toEqual([['foo','foo'],['bar','bar']]);
     });
 
     test(`should error on basic types`, () => {
@@ -195,6 +229,14 @@ describe(`clone`, () => {
         expect(cloned.get('foo')).toBe(1);
         expect(cloned.get('bar')).toBe(2);
     });
+
+    test(`should work with set`, () => {
+        const set = new Set(['foo','bar']);
+        const cloned = clone(set);
+
+        expect(cloned).not.toBe(set);
+        expect(Array.from(set.values())).toEqual(['foo','bar']);
+    });
 });
 
 describe(`create`, () => {
@@ -212,5 +254,9 @@ describe(`create`, () => {
 
     test(`MAP should create map`, () => {
         expect(create(MAP) instanceof Map).toBe(true);
+    });
+
+    test(`SET should create set`, () => {
+        expect(create(SET) instanceof Set).toBe(true);
     });
 });

--- a/packages/dendriform/.size-limit.js
+++ b/packages/dendriform/.size-limit.js
@@ -9,7 +9,7 @@ module.exports = [
         name: 'Dendriform',
         path: "dist/dendriform.esm.js",
         import: "{ Dendriform }",
-        limit: "8.6 KB",
+        limit: "8.7 KB",
         ignore: ['react', 'react-dom']
     }
 ];

--- a/packages/dendriform/.size-limit.js
+++ b/packages/dendriform/.size-limit.js
@@ -2,7 +2,7 @@ module.exports = [
     {
         name: 'everything combined',
         path: "dist/dendriform.esm.js",
-        limit: "8.6 KB",
+        limit: "9.4 KB",
         ignore: ['react', 'react-dom']
     },
     {
@@ -16,7 +16,7 @@ module.exports = [
         name: 'Dendriform',
         path: "dist/dendriform.esm.js",
         import: "{ Dendriform }",
-        limit: "7.9 KB",
+        limit: "8.6 KB",
         ignore: ['react', 'react-dom']
     },
     {

--- a/packages/dendriform/.size-limit.js
+++ b/packages/dendriform/.size-limit.js
@@ -6,45 +6,10 @@ module.exports = [
         ignore: ['react', 'react-dom']
     },
     {
-        name: 'array',
-        path: "dist/dendriform.esm.js",
-        import: "{ array }",
-        limit: "0.4 KB",
-        ignore: ['react', 'react-dom', 'immer', 'shallow-equals']
-    },
-    {
         name: 'Dendriform',
         path: "dist/dendriform.esm.js",
         import: "{ Dendriform }",
         limit: "8.6 KB",
         ignore: ['react', 'react-dom']
-    },
-    {
-        name: 'useCheckbox',
-        path: "dist/dendriform.esm.js",
-        import: "{ useCheckbox }",
-        limit: "0.2 KB",
-        ignore: ['react', 'react-dom', 'immer', 'shallow-equals']
-    },
-    {
-        name: 'useInput',
-        path: "dist/dendriform.esm.js",
-        import: "{ useInput }",
-        limit: "0.3 KB",
-        ignore: ['react', 'react-dom', 'immer', 'shallow-equals']
-    },
-    {
-        name: 'sync',
-        path: "dist/dendriform.esm.js",
-        import: "{ sync }",
-        limit: "0.4 KB",
-        ignore: ['react', 'react-dom', 'immer', 'shallow-equals']
-    },
-    {
-        name: 'useSync',
-        path: "dist/dendriform.esm.js",
-        import: "{ useSync }",
-        limit: "0.4 KB",
-        ignore: ['react', 'react-dom', 'immer', 'shallow-equals']
     }
 ];

--- a/packages/dendriform/.size-limit.js
+++ b/packages/dendriform/.size-limit.js
@@ -2,14 +2,14 @@ module.exports = [
     {
         name: 'everything combined',
         path: "dist/dendriform.esm.js",
-        limit: "9.5 KB",
+        limit: "9.8 KB",
         ignore: ['react', 'react-dom']
     },
     {
         name: 'Dendriform',
         path: "dist/dendriform.esm.js",
         import: "{ Dendriform }",
-        limit: "8.7 KB",
+        limit: "8.8 KB",
         ignore: ['react', 'react-dom']
     }
 ];

--- a/packages/dendriform/.size-limit.js
+++ b/packages/dendriform/.size-limit.js
@@ -2,7 +2,7 @@ module.exports = [
     {
         name: 'everything combined',
         path: "dist/dendriform.esm.js",
-        limit: "9.4 KB",
+        limit: "9.5 KB",
         ignore: ['react', 'react-dom']
     },
     {

--- a/packages/dendriform/package.json
+++ b/packages/dendriform/package.json
@@ -20,7 +20,7 @@
     "prepare": "tsdx build"
   },
   "dependencies": {
-    "dendriform-immer-patch-optimiser": "^1.0.0-alpha.4",
+    "dendriform-immer-patch-optimiser": "^2.0.0",
     "immer": "9.0.1",
     "shallow-equal": "1.2.1"
   },

--- a/packages/dendriform/package.json
+++ b/packages/dendriform/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "dev": "tsdx watch",
     "build": "tsdx build",
-    "test": "tsdx test --passWithNoTests --coverage --maxWorkers=2",
+    "test": "tsdx test --passWithNoTests --coverage --runInBand",
     "lint": "yarn eslint src/**/* --ext .js,.ts,.jsx,.tsx",
     "size": "yarn size-limit",
     "prepare": "tsdx build"

--- a/packages/dendriform/src/Dendriform.tsx
+++ b/packages/dendriform/src/Dendriform.tsx
@@ -68,6 +68,7 @@ export type ChangeCallbackDetails<V> = {
     patches: HistoryPatch;
     prev: StateDiff<V|undefined,Nodes|undefined>;
     next: StateDiff<V,Nodes>;
+    id: string;
 };
 export type ChangeCallback<V> = (newValue: V, details: ChangeCallbackDetails<V>) => void;
 export type ChangeTypeValue = 'value';
@@ -84,6 +85,7 @@ export type DeriveCallbackDetails<V> = {
     patches: HistoryPatch
     prev: StateDiff<V|undefined,Nodes|undefined>;
     next: StateDiff<V,Nodes>;
+    id: string;
 };
 export type DeriveCallback<V> = (newValue: V, details: DeriveCallbackDetails<V>) => void;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -473,7 +475,8 @@ export class Core<C> {
             next: {
                 value: this.state.value,
                 nodes: this.state.nodes
-            }
+            },
+            id: '0'
         };
 
         deriveCallback(this.state.value, details);
@@ -518,7 +521,8 @@ export class Core<C> {
                     next: {
                         value: nextValue,
                         nodes: this.state.nodes
-                    }
+                    },
+                    id
                 };
 
                 changeCallback(nextValue, details);

--- a/packages/dendriform/src/Dendriform.tsx
+++ b/packages/dendriform/src/Dendriform.tsx
@@ -662,6 +662,7 @@ const Branch = React.memo(
     (prevProps, nextProps) => shallowEqualArrays(prevProps.deps, nextProps.deps)
 );
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const entriesOrDie = (thing: any, error: ErrorKey) => {
     try {
         return entries(thing);
@@ -701,7 +702,9 @@ type Branchable = unknown[]
     | Set<unknown>
     | {[key: string]: unknown};
 
+
 type BranchableChild<A> = A extends unknown[] ? A[0]
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     : A extends Map<any, infer V> ? V
     : A extends Set<infer V> ? V
     : A extends {[key: string]: infer V} ? V
@@ -885,9 +888,7 @@ export class Dendriform<V> {
     branchAll(pathOrKey: any): any {
         const got = this.branch(pathOrKey);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return entriesOrDie(got.value, 2).map(([key]) => {
-            return got.branch(key as any);
-        });
+        return entriesOrDie(got.value, 2).map(([key]) => got.branch(key as any));
     }
 
     render<K1 extends Key<V>, K2 extends keyof Val<V,K1>, K3 extends keyof Val<Val<V,K1>,K2>, K4 extends keyof Val<Val<Val<V,K1>,K2>,K3>>(path: [K1, K2, K3, K4], renderer: Renderer<Dendriform<Val<Val<Val<V,K1>,K2>,K3>[K4]>>, deps?: unknown[]): React.ReactElement;

--- a/packages/dendriform/src/Dendriform.tsx
+++ b/packages/dendriform/src/Dendriform.tsx
@@ -238,10 +238,14 @@ export class Core<C> {
         return getIn(this.state.value, path);
     };
 
+    getKey = (id: string): unknown => {
+        const path = this.getPath(id);
+        return path ? path.slice(-1)[0] : undefined;
+    };
+
     getIndex = (id: string): number => {
         const path = this.getPath(id);
-        if(!path) return -1;
-        const [key] = path.slice(-1);
+        const key =  path ? path.slice(-1)[0] : -1;
         if(typeof key !== 'number') die(4, path);
         return key;
     };
@@ -740,6 +744,13 @@ export class Dendriform<V> {
 
     get value(): V {
         return this.core.getValue(this.id) as V;
+    }
+
+    get key(): unknown {
+        // this is typed as unknown for now
+        // in future we could use generics to work out what the key is
+        // but the order of generics in the Dendriform type is not yet decided
+        return this.core.getKey(this.id);
     }
 
     get index(): number {

--- a/packages/dendriform/src/Dendriform.tsx
+++ b/packages/dendriform/src/Dendriform.tsx
@@ -779,7 +779,7 @@ export class Dendriform<V> {
         try {
             this.core.derive(deriveCallback, 0, true, false);
         } catch(e) {
-            die(6, '?');
+            die(6, e.message);
         }
         this.core.callAllChangeCallbacks();
 

--- a/packages/dendriform/src/Nodes.ts
+++ b/packages/dendriform/src/Nodes.ts
@@ -31,16 +31,14 @@ export type NodeAny = NodeObject|NodeArray|NodeBasic|NodeMap;
 
 export type Nodes = {[id: string]: NodeAny};
 
-export type CountRef = {
-    current: number;
-};
+export type GetNextId = () => string;
 
 export type NewNodeCreator = (value: unknown, parentId?: string) => NodeAny;
 
-export const newNode = (countRef: CountRef): NewNodeCreator => {
+export const newNode = (getNextId: GetNextId): NewNodeCreator => {
     return (value: unknown, parentId = ''): NodeAny => {
         const type = getType(value);
-        const id = `${countRef.current++}`;
+        const id = getNextId();
         return {
             type,
             child: create(type),

--- a/packages/dendriform/src/Nodes.ts
+++ b/packages/dendriform/src/Nodes.ts
@@ -1,4 +1,4 @@
-import {BASIC, OBJECT, ARRAY, MAP, getType, has, get, set, entries, create, applyPatches} from 'dendriform-immer-patch-optimiser';
+import {BASIC, OBJECT, ARRAY, MAP, SET, getType, has, get, set, entries, create, applyPatches} from 'dendriform-immer-patch-optimiser';
 import type {Path, DendriformPatch} from 'dendriform-immer-patch-optimiser';
 import {produceWithPatches} from 'immer';
 
@@ -22,12 +22,17 @@ export type NodeMap = {
     child?: Map<string|number,string>;
 } & NodeCommon;
 
+export type NodeSet = {
+    type: typeof SET;
+    child?: Map<string|number,string>;
+} & NodeCommon;
+
 export type NodeBasic = {
     type: typeof BASIC;
     child: undefined;
 } & NodeCommon;
 
-export type NodeAny = NodeObject|NodeArray|NodeBasic|NodeMap;
+export type NodeAny = NodeObject|NodeArray|NodeBasic|NodeMap|NodeSet;
 
 export type Nodes = {[id: string]: NodeAny};
 
@@ -41,7 +46,7 @@ export const newNode = (getNextId: GetNextId): NewNodeCreator => {
         const id = getNextId();
         return {
             type,
-            child: create(type),
+            child: create(type === SET ? MAP : type),
             parentId,
             id
         };

--- a/packages/dendriform/src/Nodes.ts
+++ b/packages/dendriform/src/Nodes.ts
@@ -1,4 +1,4 @@
-import {BASIC, OBJECT, ARRAY, MAP, getType, has, get, set, each, create, applyPatches} from 'dendriform-immer-patch-optimiser';
+import {BASIC, OBJECT, ARRAY, MAP, getType, has, get, set, entries, create, applyPatches} from 'dendriform-immer-patch-optimiser';
 import type {Path, DendriformPatch} from 'dendriform-immer-patch-optimiser';
 import {produceWithPatches} from 'immer';
 
@@ -93,13 +93,7 @@ export const getNodeByPath = <P = unknown>(
 };
 
 const _getKey = (parentNode: NodeAny, childNode: NodeAny): number|string|undefined => {
-    let key = undefined;
-    each(parentNode.child, (childId, childKey) => {
-        if(childId === childNode.id) {
-            key = childKey;
-        }
-    });
-    return key;
+    return entries(parentNode.child).find(([,childId]) => childId === childNode.id)?.[0];
 };
 
 export const getPath = (nodes: Nodes, id: string): Path|undefined => {
@@ -123,7 +117,7 @@ export const removeNode = (nodes: Nodes, id: string, onlyChildren = false): void
     if(!node) return;
 
     if(node.child) {
-        each(node.child, id => removeNode(nodes, id as string));
+        entries(node.child).forEach(([,id]) => removeNode(nodes, id as string));
     }
     if(!onlyChildren) {
         delete nodes[id];
@@ -137,7 +131,7 @@ export const updateNode = (nodes: Nodes, id: string, value: unknown): void => {
     const type = getType(value);
     if(type === node.type) {
         if(type === BASIC) return;
-        each(node.child, (childId, childKey) => {
+        entries(node.child).forEach(([childKey,childId]) => {
             if(has(value, childKey)) {
                 updateNode(nodes, childId as string, get(value, childKey));
             } else {

--- a/packages/dendriform/src/diff.ts
+++ b/packages/dendriform/src/diff.ts
@@ -1,0 +1,114 @@
+import type {StateDiff} from './index';
+import type {Key, DataType} from 'dendriform-immer-patch-optimiser';
+import type {Nodes} from './Nodes';
+
+import {BASIC, ARRAY, get, getType, entries} from 'dendriform-immer-patch-optimiser';
+
+const getArrayNodeChild = (type: DataType, nodes?: Nodes, id?: string): Key[]|undefined => {
+    if(type !== ARRAY) {
+        return undefined;
+    }
+    return (nodes && id)
+        ? nodes[id].child as Key[]
+        : [];
+};
+
+const getIds = <V,>(type: DataType, value?: V, arrayNodeChild?: Key[]): Key[] => {
+    if(arrayNodeChild) {
+        return arrayNodeChild;
+    }
+    if(type === BASIC) {
+        return [];
+    }
+    return entries(value).map(([key]) => key);
+};
+
+const idsToKeys = (ids: Key[], arrayNodeChild?: Key[]): Key[] => {
+    if(!arrayNodeChild) {
+        return ids;
+    }
+    return ids.map(id => arrayNodeChild.indexOf(id));
+};
+
+const keysToDiffs = <V,>(keys: Key[], value: V): Diff<V>[] => {
+    return keys.map(key => ({
+        key,
+        value: get(value, key) as V
+    }));
+};
+
+export type DiffDetails<V> = {
+    prev: StateDiff<V|undefined,Nodes|undefined>;
+    next: StateDiff<V,Nodes>;
+    id: string;
+};
+
+export type Diff<V> = {
+    key: Key;
+    value: V;
+};
+
+export type DiffOptions = {
+    calculateUpdated?: boolean;
+};
+
+export const diff = <V,>(details: DiffDetails<V>, options: DiffOptions = {}): [Diff<V>[], Diff<V>[], Diff<V>[]] => {
+
+    const {calculateUpdated = true} = options;
+
+    const prevValue = details.prev.value;
+    const nextValue = details.next.value;
+
+    const prevNodes = details.prev.nodes;
+    const nextNodes = details.next.nodes;
+
+    const prevType = getType(prevValue);
+    const nextType = getType(nextValue);
+
+    const prevArrayNodeChild = getArrayNodeChild(prevType, prevNodes, details.id);
+    const nextArrayNodeChild = getArrayNodeChild(nextType, nextNodes, details.id);
+
+    const prevIds = getIds<V>(prevType, prevValue, prevArrayNodeChild);
+    const nextIds = getIds<V>(nextType, nextValue, nextArrayNodeChild);
+
+    const prevIdsSet = new Set(prevIds);
+    const nextIdsSet = new Set(nextIds);
+
+    const addedIds = nextIds.filter(key => !prevIdsSet.has(key));
+    const removedIds = prevIds.filter(key => !nextIdsSet.has(key));
+
+    const addedKeys = idsToKeys(addedIds, nextArrayNodeChild);
+    const removedKeys = idsToKeys(removedIds, prevArrayNodeChild);
+
+    const addedDiffs = keysToDiffs<V>(addedKeys, nextValue);
+    const removedDiffs = keysToDiffs<V>(removedKeys, prevValue as V);
+
+    if(!calculateUpdated) {
+        return [
+            addedDiffs,
+            removedDiffs,
+            []
+        ];
+    }
+
+    const continuedIds = nextIds.filter(key => prevIdsSet.has(key));
+
+    const continuedPrevKeys = idsToKeys(continuedIds, prevArrayNodeChild);
+    const continuedNextKeys = idsToKeys(continuedIds, nextArrayNodeChild);
+
+    const continuedPrevDiffs = keysToDiffs<V>(continuedPrevKeys, prevValue as V);
+    const continuedNextDiffs = keysToDiffs<V>(continuedNextKeys, nextValue);
+
+    const updatedDiffs = continuedNextDiffs
+        .map((diff, index): Diff<V>|undefined => {
+            return Object.is(continuedPrevDiffs[index].value, diff.value) ? undefined : diff;
+        })
+        .filter((diff): diff is Diff<V> => !!diff);
+
+    return [
+        addedDiffs,
+        removedDiffs,
+        updatedDiffs
+    ];
+};
+

--- a/packages/dendriform/src/errors.ts
+++ b/packages/dendriform/src/errors.ts
@@ -7,7 +7,8 @@ const errors = {
     3: `renderAll() ${all}`,
     4: (path: unknown[]) => `useIndex() can only be called on array element forms, can't be called at path ${path.map(a => JSON.stringify(a)).join('","')}`,
     5: `sync() forms must have the same maximum number of history items configured`,
-    6: (msg: string) => `onDerive() callback must not throw errors on first call. Threw: ${msg}`
+    6: (msg: string) => `onDerive() callback must not throw errors on first call. Threw: ${msg}`,
+    7: `Cannot call .set() on an element of an es6 Set`
 } as const;
 
 export type ErrorKey = keyof typeof errors;

--- a/packages/dendriform/src/errors.ts
+++ b/packages/dendriform/src/errors.ts
@@ -4,7 +4,8 @@ const errors = {
     2: 'branchAll() can only be called on forms containing arrays',
     3: 'renderAll() can only be called on forms containing arrays',
     4: (path: unknown[]) => `useIndex() can only be called on array element forms, can't be called at path ${path.map(a => JSON.stringify(a)).join('","')}`,
-    5: `sync() forms must have the same maximum number of history items configured`
+    5: `sync() forms must have the same maximum number of history items configured`,
+    6: (msg: string) => `onDerive() callback must not throw errors on first call. Threw: ${msg}`
 } as const;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -14,8 +15,9 @@ export function die(error: keyof typeof errors, ...args: any[]): never {
         const msg = !e
             ? `unknown error #${error}`
             : typeof e === 'function'
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                ? e(args as any)
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                ? e(args)
                 : e;
 
         throw new Error(`[Dendriform] ${msg}`);

--- a/packages/dendriform/src/errors.ts
+++ b/packages/dendriform/src/errors.ts
@@ -1,4 +1,4 @@
-const all = `can only be called on forms containing an array, object, es6 map or es6 set`
+const all = `can only be called on forms containing an array, object, es6 map or es6 set`;
 
 const errors = {
     0: (id: number) => `Cannot find path of node ${id}`,

--- a/packages/dendriform/src/errors.ts
+++ b/packages/dendriform/src/errors.ts
@@ -1,15 +1,19 @@
+const all = `can only be called on forms containing an array, object, es6 map or es6 set`
+
 const errors = {
     0: (id: number) => `Cannot find path of node ${id}`,
     // 1: (path: unknown[]) => `Cannot find node at path ${path.map(a => JSON.stringify(a)).join('","')}`,
-    2: 'branchAll() can only be called on forms containing arrays',
-    3: 'renderAll() can only be called on forms containing arrays',
+    2: `branchAll() ${all}`,
+    3: `renderAll() ${all}`,
     4: (path: unknown[]) => `useIndex() can only be called on array element forms, can't be called at path ${path.map(a => JSON.stringify(a)).join('","')}`,
     5: `sync() forms must have the same maximum number of history items configured`,
     6: (msg: string) => `onDerive() callback must not throw errors on first call. Threw: ${msg}`
 } as const;
 
+export type ErrorKey = keyof typeof errors;
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function die(error: keyof typeof errors, ...args: any[]): never {
+export function die(error: ErrorKey, ...args: any[]): never {
     if(__DEV__) {
         const e = errors[error];
         const msg = !e

--- a/packages/dendriform/src/index.ts
+++ b/packages/dendriform/src/index.ts
@@ -7,4 +7,5 @@ export * from './useInput';
 export * from './useCheckbox';
 export * from './useProps';
 export * from './sync';
+export * from './diff';
 export {immerable} from 'immer';

--- a/packages/dendriform/src/sync.ts
+++ b/packages/dendriform/src/sync.ts
@@ -13,7 +13,7 @@ export const sync = <V,S>(
         die(5);
     }
 
-    const unsubMaster = masterForm.onDerive((newValue: V, details: DeriveCallbackDetails) => {
+    const unsubMaster = masterForm.onDerive((newValue: V, details: DeriveCallbackDetails<V>) => {
         const {go, replace} = details;
         // if master form calls go(), slave form calls go()
         if(go) return slaveForm.go(go);
@@ -22,7 +22,7 @@ export const sync = <V,S>(
         derive ? derive(newValue, details) : slaveForm.set(noChange);
     });
 
-    const unsubSlave = slaveForm.onDerive((_newValue: S, details: DeriveCallbackDetails) => {
+    const unsubSlave = slaveForm.onDerive((_newValue: S, details: DeriveCallbackDetails<S>) => {
         const {go, replace} = details;
         // if slave form calls go(), master form calls go()
         if(go) return masterForm.go(go);

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -108,6 +108,13 @@ describe(`Dendriform`, () => {
         });
     });
 
+    describe('.key', () => {
+        test(`should provide key`, () => {
+            const form = new Dendriform({foo: 'bar'});
+            expect(form.branch('foo').key).toBe('foo');
+        });
+    });
+
     describe('.index and .useIndex()', () => {
         test(`should provide index and produce an update`, () => {
 

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -176,37 +176,37 @@ describe(`Dendriform`, () => {
         test(`should undo`, () => {
             const form = new Dendriform(123, {history: 100});
 
-            expect(form.core.historyStack.length).toBe(0);
-            expect(form.core.historyIndex).toBe(0);
+            expect(form.core.state.historyStack.length).toBe(0);
+            expect(form.core.state.historyIndex).toBe(0);
 
             form.set(456);
 
-            expect(form.core.historyStack.length).toBe(1);
-            expect(form.core.historyIndex).toBe(1);
+            expect(form.core.state.historyStack.length).toBe(1);
+            expect(form.core.state.historyIndex).toBe(1);
 
             form.set(789);
 
-            expect(form.core.historyStack.length).toBe(2);
-            expect(form.core.historyIndex).toBe(2);
+            expect(form.core.state.historyStack.length).toBe(2);
+            expect(form.core.state.historyIndex).toBe(2);
             expect(form.value).toBe(789);
 
             form.undo();
 
             expect(form.value).toBe(456);
-            expect(form.core.historyStack.length).toBe(2);
-            expect(form.core.historyIndex).toBe(1);
+            expect(form.core.state.historyStack.length).toBe(2);
+            expect(form.core.state.historyIndex).toBe(1);
 
             form.undo();
 
             expect(form.value).toBe(123);
-            expect(form.core.historyStack.length).toBe(2);
-            expect(form.core.historyIndex).toBe(0);
+            expect(form.core.state.historyStack.length).toBe(2);
+            expect(form.core.state.historyIndex).toBe(0);
 
             form.undo();
 
             expect(form.value).toBe(123);
-            expect(form.core.historyStack.length).toBe(2);
-            expect(form.core.historyIndex).toBe(0);
+            expect(form.core.state.historyStack.length).toBe(2);
+            expect(form.core.state.historyIndex).toBe(0);
         });
 
         test(`should not undo if no history is configured`, () => {
@@ -365,18 +365,18 @@ describe(`Dendriform`, () => {
             form.set(200);
 
             expect(form.value).toBe(200);
-            expect(form.core.historyStack.length).toBe(1);
+            expect(form.core.state.historyStack.length).toBe(1);
 
             form.replace();
             form.set(300);
 
             expect(form.value).toBe(300);
-            expect(form.core.historyStack.length).toBe(1);
+            expect(form.core.state.historyStack.length).toBe(1);
 
             form.set(400);
 
             expect(form.value).toBe(400);
-            expect(form.core.historyStack.length).toBe(2);
+            expect(form.core.state.historyStack.length).toBe(2);
 
             form.undo();
 
@@ -402,7 +402,7 @@ describe(`Dendriform`, () => {
             form.done();
 
             expect(form.value).toBe(400);
-            expect(form.core.historyStack.length).toBe(3);
+            expect(form.core.state.historyStack.length).toBe(3);
 
             form.undo();
 
@@ -427,7 +427,7 @@ describe(`Dendriform`, () => {
             form.done();
 
             expect(form.value).toBe(300);
-            expect(form.core.historyStack.length).toBe(1);
+            expect(form.core.state.historyStack.length).toBe(1);
 
             form.undo();
 
@@ -533,11 +533,11 @@ describe(`Dendriform`, () => {
             const form = new Dendriform(['A','B','C']);
 
             const secondElement = form.branch(1);
-            const nodesBefore = form.core.nodes;
+            const nodesBefore = form.core.state.nodes;
             secondElement.set('B!');
 
             expect(form.value).toEqual(['A','B!','C']);
-            expect(form.core.nodes).toEqual(nodesBefore);
+            expect(form.core.state.nodes).toEqual(nodesBefore);
         });
 
         test(`should produce child value with immer producer`, () => {
@@ -574,11 +574,11 @@ describe(`Dendriform`, () => {
                 const form = new Dendriform<NotSetTestValue>({foo: 'a'});
 
                 const bForm = form.branch('bar');
-                const nodesBefore = form.core.nodes;
+                const nodesBefore = form.core.state.nodes;
                 bForm.set('B!');
 
                 expect(form.value).toEqual({foo: 'a', bar: 'B!'});
-                expect(form.core.nodes).toEqual(nodesBefore);
+                expect(form.core.state.nodes).toEqual(nodesBefore);
             });
         });
 
@@ -715,11 +715,11 @@ describe(`Dendriform`, () => {
             const form = new Dendriform(['A','B','C']);
 
             const forms = form.branchAll();
-            const nodesBefore = form.core.nodes;
+            const nodesBefore = form.core.state.nodes;
             forms[1].set('B!');
 
             expect(form.value).toEqual(['A','B!','C']);
-            expect(form.core.nodes).toEqual(nodesBefore);
+            expect(form.core.state.nodes).toEqual(nodesBefore);
         });
 
         test(`should return same instance for all .branchAll()s to same child`, () => {
@@ -1527,8 +1527,8 @@ describe(`Dendriform`, () => {
 
             form.branch('name').set('boooo');
 
-            expect(form.core.historyStack.length).toBe(1);
-            expect(form.core.historyIndex).toBe(1);
+            expect(form.core.state.historyStack.length).toBe(1);
+            expect(form.core.state.historyIndex).toBe(1);
 
             expect(deriver).toHaveBeenCalledTimes(2);
             expect(deriver.mock.calls[1][0]).toEqual({
@@ -1557,8 +1557,8 @@ describe(`Dendriform`, () => {
 
             form.undo();
 
-            expect(form.core.historyStack.length).toBe(1);
-            expect(form.core.historyIndex).toBe(0);
+            expect(form.core.state.historyStack.length).toBe(1);
+            expect(form.core.state.historyIndex).toBe(0);
 
             expect(deriver).toHaveBeenCalledTimes(3);
             expect(deriver.mock.calls[2][0]).toEqual({
@@ -1590,8 +1590,8 @@ describe(`Dendriform`, () => {
 
             form.redo();
 
-            expect(form.core.historyStack.length).toBe(1);
-            expect(form.core.historyIndex).toBe(1);
+            expect(form.core.state.historyStack.length).toBe(1);
+            expect(form.core.state.historyIndex).toBe(1);
 
             expect(deriver).toHaveBeenCalledTimes(4);
             expect(deriver.mock.calls[3][0]).toEqual({
@@ -1639,8 +1639,8 @@ describe(`Dendriform`, () => {
 
             form.branch('name').set('boooo');
 
-            expect(form.core.historyStack.length).toBe(1);
-            expect(form.core.historyIndex).toBe(1);
+            expect(form.core.state.historyStack.length).toBe(1);
+            expect(form.core.state.historyIndex).toBe(1);
 
             expect(deriver).toHaveBeenCalledTimes(2);
             expect(deriver.mock.calls[1][0]).toEqual({
@@ -1670,8 +1670,8 @@ describe(`Dendriform`, () => {
             form.replace();
             form.branch('name').set('!!!!!!!');
 
-            expect(form.core.historyStack.length).toBe(1);
-            expect(form.core.historyIndex).toBe(1);
+            expect(form.core.state.historyStack.length).toBe(1);
+            expect(form.core.state.historyIndex).toBe(1);
 
             expect(deriver).toHaveBeenCalledTimes(3);
             expect(deriver.mock.calls[2][0]).toEqual({
@@ -1700,8 +1700,8 @@ describe(`Dendriform`, () => {
 
             form.undo();
 
-            expect(form.core.historyStack.length).toBe(1);
-            expect(form.core.historyIndex).toBe(0);
+            expect(form.core.state.historyStack.length).toBe(1);
+            expect(form.core.state.historyIndex).toBe(0);
 
             expect(deriver).toHaveBeenCalledTimes(4);
             expect(deriver.mock.calls[3][0]).toEqual({
@@ -1738,8 +1738,8 @@ describe(`Dendriform`, () => {
 
             form.redo();
 
-            expect(form.core.historyStack.length).toBe(1);
-            expect(form.core.historyIndex).toBe(1);
+            expect(form.core.state.historyStack.length).toBe(1);
+            expect(form.core.state.historyIndex).toBe(1);
 
             expect(deriver).toHaveBeenCalledTimes(5);
             expect(deriver.mock.calls[4][0]).toEqual({
@@ -1871,19 +1871,19 @@ describe(`Dendriform`, () => {
                 form2.set(2);
 
                 expect(form2.value).toBe(2);
-                expect(form2.core.historyStack.length).toBe(0);
-                expect(form2.core.historyIndex).toBe(0);
+                expect(form2.core.state.historyStack.length).toBe(0);
+                expect(form2.core.state.historyIndex).toBe(0);
 
                 // make a change to master, and now slave should have a history item
 
                 form.set(200);
 
                 expect(form.value).toBe(200);
-                expect(form.core.historyStack.length).toBe(1);
-                expect(form.core.historyIndex).toBe(1);
+                expect(form.core.state.historyStack.length).toBe(1);
+                expect(form.core.state.historyIndex).toBe(1);
                 expect(form2.value).toBe(2);
-                expect(form2.core.historyStack.length).toBe(1);
-                expect(form2.core.historyIndex).toBe(1);
+                expect(form2.core.state.historyStack.length).toBe(1);
+                expect(form2.core.state.historyIndex).toBe(1);
 
                 // make a couple more changes to slave
 
@@ -1896,11 +1896,11 @@ describe(`Dendriform`, () => {
                 form.undo();
 
                 expect(form.value).toBe(100);
-                expect(form.core.historyStack.length).toBe(1);
-                expect(form.core.historyIndex).toBe(0);
+                expect(form.core.state.historyStack.length).toBe(1);
+                expect(form.core.state.historyIndex).toBe(0);
                 expect(form2.value).toBe(2);
-                expect(form2.core.historyStack.length).toBe(1);
-                expect(form2.core.historyIndex).toBe(0);
+                expect(form2.core.state.historyStack.length).toBe(1);
+                expect(form2.core.state.historyIndex).toBe(0);
 
                 // now redo master, slave should go back to the state it was in
                 // when master change #2 happened
@@ -1908,11 +1908,11 @@ describe(`Dendriform`, () => {
                 form.redo();
 
                 expect(form.value).toBe(200);
-                expect(form.core.historyStack.length).toBe(1);
-                expect(form.core.historyIndex).toBe(1);
+                expect(form.core.state.historyStack.length).toBe(1);
+                expect(form.core.state.historyIndex).toBe(1);
                 expect(form2.value).toBe(4);
-                expect(form2.core.historyStack.length).toBe(1);
-                expect(form2.core.historyIndex).toBe(1);
+                expect(form2.core.state.historyStack.length).toBe(1);
+                expect(form2.core.state.historyIndex).toBe(1);
 
 
             });
@@ -1941,10 +1941,10 @@ describe(`Dendriform`, () => {
 
                     expect(form.value).toBe('1');
                     expect(form2.value).toBe('1?');
-                    expect(form.core.historyStack.length).toBe(0);
-                    expect(form2.core.historyStack.length).toBe(0);
-                    expect(form.core.historyIndex).toBe(0);
-                    expect(form2.core.historyIndex).toBe(0);
+                    expect(form.core.state.historyStack.length).toBe(0);
+                    expect(form2.core.state.historyStack.length).toBe(0);
+                    expect(form.core.state.historyIndex).toBe(0);
+                    expect(form2.core.state.historyIndex).toBe(0);
 
                     // set value of form 1
 
@@ -1952,10 +1952,10 @@ describe(`Dendriform`, () => {
 
                     expect(form.value).toBe('2');
                     expect(form2.value).toBe('2?');
-                    expect(form.core.historyStack.length).toBe(1);
-                    expect(form2.core.historyStack.length).toBe(1);
-                    expect(form.core.historyIndex).toBe(1);
-                    expect(form2.core.historyIndex).toBe(1);
+                    expect(form.core.state.historyStack.length).toBe(1);
+                    expect(form2.core.state.historyStack.length).toBe(1);
+                    expect(form.core.state.historyIndex).toBe(1);
+                    expect(form2.core.state.historyIndex).toBe(1);
 
                     // set value of form 2
 
@@ -1963,10 +1963,10 @@ describe(`Dendriform`, () => {
 
                     expect(form.value).toBe('2');
                     expect(form2.value).toBe('!!!');
-                    expect(form.core.historyStack.length).toBe(2);
-                    expect(form2.core.historyStack.length).toBe(2);
-                    expect(form.core.historyIndex).toBe(2);
-                    expect(form2.core.historyIndex).toBe(2);
+                    expect(form.core.state.historyStack.length).toBe(2);
+                    expect(form2.core.state.historyStack.length).toBe(2);
+                    expect(form.core.state.historyIndex).toBe(2);
+                    expect(form2.core.state.historyIndex).toBe(2);
 
                     // should undo()
 
@@ -1974,10 +1974,10 @@ describe(`Dendriform`, () => {
 
                     expect(form.value).toBe('2');
                     expect(form2.value).toBe('2?');
-                    expect(form.core.historyStack.length).toBe(2);
-                    expect(form2.core.historyStack.length).toBe(2);
-                    expect(form.core.historyIndex).toBe(1);
-                    expect(form2.core.historyIndex).toBe(1);
+                    expect(form.core.state.historyStack.length).toBe(2);
+                    expect(form2.core.state.historyStack.length).toBe(2);
+                    expect(form.core.state.historyIndex).toBe(1);
+                    expect(form2.core.state.historyIndex).toBe(1);
 
                     // should redo()
 
@@ -1985,10 +1985,10 @@ describe(`Dendriform`, () => {
 
                     expect(form.value).toBe('2');
                     expect(form2.value).toBe('!!!');
-                    expect(form.core.historyStack.length).toBe(2);
-                    expect(form2.core.historyStack.length).toBe(2);
-                    expect(form.core.historyIndex).toBe(2);
-                    expect(form2.core.historyIndex).toBe(2);
+                    expect(form.core.state.historyStack.length).toBe(2);
+                    expect(form2.core.state.historyStack.length).toBe(2);
+                    expect(form.core.state.historyIndex).toBe(2);
+                    expect(form2.core.state.historyIndex).toBe(2);
 
                     // should undo() other
 
@@ -1996,8 +1996,8 @@ describe(`Dendriform`, () => {
 
                     expect(form.value).toBe('2');
                     expect(form2.value).toBe('2?');
-                    expect(form.core.historyStack.length).toBe(2);
-                    expect(form2.core.historyStack.length).toBe(2);
+                    expect(form.core.state.historyStack.length).toBe(2);
+                    expect(form2.core.state.historyStack.length).toBe(2);
 
                     // should redo() other
 
@@ -2005,8 +2005,8 @@ describe(`Dendriform`, () => {
 
                     expect(form.value).toBe('2');
                     expect(form2.value).toBe('!!!');
-                    expect(form.core.historyStack.length).toBe(2);
-                    expect(form2.core.historyStack.length).toBe(2);
+                    expect(form.core.state.historyStack.length).toBe(2);
+                    expect(form2.core.state.historyStack.length).toBe(2);
 
                     // should unsync
 
@@ -2027,10 +2027,10 @@ describe(`Dendriform`, () => {
 
                     expect(form.value).toBe('');
                     expect(form2.value).toBe('');
-                    expect(form.core.historyStack.length).toBe(0);
-                    expect(form2.core.historyStack.length).toBe(0);
-                    expect(form.core.historyIndex).toBe(0);
-                    expect(form2.core.historyIndex).toBe(0);
+                    expect(form.core.state.historyStack.length).toBe(0);
+                    expect(form2.core.state.historyStack.length).toBe(0);
+                    expect(form.core.state.historyIndex).toBe(0);
+                    expect(form2.core.state.historyIndex).toBe(0);
 
                     // set value of form 1
 
@@ -2038,10 +2038,10 @@ describe(`Dendriform`, () => {
 
                     expect(form.value).toBe('A');
                     expect(form2.value).toBe('');
-                    expect(form.core.historyStack.length).toBe(1);
-                    expect(form2.core.historyStack.length).toBe(1);
-                    expect(form.core.historyIndex).toBe(1);
-                    expect(form2.core.historyIndex).toBe(1);
+                    expect(form.core.state.historyStack.length).toBe(1);
+                    expect(form2.core.state.historyStack.length).toBe(1);
+                    expect(form.core.state.historyIndex).toBe(1);
+                    expect(form2.core.state.historyIndex).toBe(1);
 
                     // set value of form 2
 
@@ -2049,10 +2049,10 @@ describe(`Dendriform`, () => {
 
                     expect(form.value).toBe('A');
                     expect(form2.value).toBe('B');
-                    expect(form.core.historyStack.length).toBe(2);
-                    expect(form2.core.historyStack.length).toBe(2);
-                    expect(form.core.historyIndex).toBe(2);
-                    expect(form2.core.historyIndex).toBe(2);
+                    expect(form.core.state.historyStack.length).toBe(2);
+                    expect(form2.core.state.historyStack.length).toBe(2);
+                    expect(form.core.state.historyIndex).toBe(2);
+                    expect(form2.core.state.historyIndex).toBe(2);
 
                     // should undo()
 
@@ -2060,10 +2060,10 @@ describe(`Dendriform`, () => {
 
                     expect(form.value).toBe('A');
                     expect(form2.value).toBe('');
-                    expect(form.core.historyStack.length).toBe(2);
-                    expect(form2.core.historyStack.length).toBe(2);
-                    expect(form.core.historyIndex).toBe(1);
-                    expect(form2.core.historyIndex).toBe(1);
+                    expect(form.core.state.historyStack.length).toBe(2);
+                    expect(form2.core.state.historyStack.length).toBe(2);
+                    expect(form.core.state.historyIndex).toBe(1);
+                    expect(form2.core.state.historyIndex).toBe(1);
 
                     // should undo() again
 
@@ -2071,10 +2071,10 @@ describe(`Dendriform`, () => {
 
                     expect(form.value).toBe('');
                     expect(form2.value).toBe('');
-                    expect(form.core.historyStack.length).toBe(2);
-                    expect(form2.core.historyStack.length).toBe(2);
-                    expect(form.core.historyIndex).toBe(0);
-                    expect(form2.core.historyIndex).toBe(0);
+                    expect(form.core.state.historyStack.length).toBe(2);
+                    expect(form2.core.state.historyStack.length).toBe(2);
+                    expect(form.core.state.historyIndex).toBe(0);
+                    expect(form2.core.state.historyIndex).toBe(0);
                 });
 
                 test(`should sync history stacks between 2 forms, and replace`, () => {
@@ -2094,10 +2094,10 @@ describe(`Dendriform`, () => {
 
                     expect(form.value).toBe('1');
                     expect(form2.value).toBe('1?');
-                    expect(form.core.historyStack.length).toBe(0);
-                    expect(form2.core.historyStack.length).toBe(0);
-                    expect(form.core.historyIndex).toBe(0);
-                    expect(form2.core.historyIndex).toBe(0);
+                    expect(form.core.state.historyStack.length).toBe(0);
+                    expect(form2.core.state.historyStack.length).toBe(0);
+                    expect(form.core.state.historyIndex).toBe(0);
+                    expect(form2.core.state.historyIndex).toBe(0);
 
                     // set value of form 1
 
@@ -2105,10 +2105,10 @@ describe(`Dendriform`, () => {
 
                     expect(form.value).toBe('2');
                     expect(form2.value).toBe('2?');
-                    expect(form.core.historyStack.length).toBe(1);
-                    expect(form2.core.historyStack.length).toBe(1);
-                    expect(form.core.historyIndex).toBe(1);
-                    expect(form2.core.historyIndex).toBe(1);
+                    expect(form.core.state.historyStack.length).toBe(1);
+                    expect(form2.core.state.historyStack.length).toBe(1);
+                    expect(form.core.state.historyIndex).toBe(1);
+                    expect(form2.core.state.historyIndex).toBe(1);
 
                     // set and replace
 
@@ -2117,10 +2117,10 @@ describe(`Dendriform`, () => {
 
                     expect(form.value).toBe('3');
                     expect(form2.value).toBe('3?');
-                    expect(form.core.historyStack.length).toBe(1);
-                    expect(form2.core.historyStack.length).toBe(1);
-                    expect(form.core.historyIndex).toBe(1);
-                    expect(form2.core.historyIndex).toBe(1);
+                    expect(form.core.state.historyStack.length).toBe(1);
+                    expect(form2.core.state.historyStack.length).toBe(1);
+                    expect(form.core.state.historyIndex).toBe(1);
+                    expect(form2.core.state.historyIndex).toBe(1);
 
                     // set regularly again
 
@@ -2128,10 +2128,10 @@ describe(`Dendriform`, () => {
 
                     expect(form.value).toBe('4');
                     expect(form2.value).toBe('4?');
-                    expect(form.core.historyStack.length).toBe(2);
-                    expect(form2.core.historyStack.length).toBe(2);
-                    expect(form.core.historyIndex).toBe(2);
-                    expect(form2.core.historyIndex).toBe(2);
+                    expect(form.core.state.historyStack.length).toBe(2);
+                    expect(form2.core.state.historyStack.length).toBe(2);
+                    expect(form.core.state.historyIndex).toBe(2);
+                    expect(form2.core.state.historyIndex).toBe(2);
 
                     // should undo()
 
@@ -2139,19 +2139,19 @@ describe(`Dendriform`, () => {
 
                     expect(form.value).toBe('3');
                     expect(form2.value).toBe('3?');
-                    expect(form.core.historyStack.length).toBe(2);
-                    expect(form2.core.historyStack.length).toBe(2);
-                    expect(form.core.historyIndex).toBe(1);
-                    expect(form2.core.historyIndex).toBe(1);
+                    expect(form.core.state.historyStack.length).toBe(2);
+                    expect(form2.core.state.historyStack.length).toBe(2);
+                    expect(form.core.state.historyIndex).toBe(1);
+                    expect(form2.core.state.historyIndex).toBe(1);
 
                     form.undo();
 
                     expect(form.value).toBe('1');
                     expect(form2.value).toBe('1?');
-                    expect(form.core.historyStack.length).toBe(2);
-                    expect(form2.core.historyStack.length).toBe(2);
-                    expect(form.core.historyIndex).toBe(0);
-                    expect(form2.core.historyIndex).toBe(0);
+                    expect(form.core.state.historyStack.length).toBe(2);
+                    expect(form2.core.state.historyStack.length).toBe(2);
+                    expect(form.core.state.historyIndex).toBe(0);
+                    expect(form2.core.state.historyIndex).toBe(0);
                 });
 
                 test(`should error if synced forms do not have the same history items`, () => {
@@ -2226,7 +2226,7 @@ describe(`Dendriform`, () => {
             });
 
 
-            expect(form.core.nodes).toEqual({
+            expect(form.core.state.nodes).toEqual({
                 '0': {
                     child: {},
                     id: '0',
@@ -2237,7 +2237,7 @@ describe(`Dendriform`, () => {
 
             form.branch('foo');
 
-            expect(form.core.nodes).toEqual({
+            expect(form.core.state.nodes).toEqual({
                 '0': {
                     child: {
                         foo: '1'
@@ -2256,7 +2256,7 @@ describe(`Dendriform`, () => {
 
             form.branch(['foo','bar']);
 
-            expect(form.core.nodes).toEqual({
+            expect(form.core.state.nodes).toEqual({
                 '0': {
                     child: {
                         foo: '1'
@@ -2291,7 +2291,7 @@ describe(`Dendriform`, () => {
 
             form.branch(['foo','bar']);
 
-            expect(form.core.nodes).toEqual({
+            expect(form.core.state.nodes).toEqual({
                 '0': {
                     child: {
                         foo: '1'
@@ -2317,7 +2317,7 @@ describe(`Dendriform`, () => {
 
             form.branch('foo').set({});
 
-            expect(form.core.nodes).toEqual({
+            expect(form.core.state.nodes).toEqual({
                 '0': {
                     child: {
                         foo: '1'
@@ -2345,7 +2345,7 @@ describe(`Dendriform`, () => {
 
             form.branch(['foo','bar']);
 
-            expect(form.core.nodes).toEqual({
+            expect(form.core.state.nodes).toEqual({
                 '0': {
                     child: {
                         foo: '1'
@@ -2371,7 +2371,7 @@ describe(`Dendriform`, () => {
 
             form.branch('foo').set([]);
 
-            expect(form.core.nodes).toEqual({
+            expect(form.core.state.nodes).toEqual({
                 '0': {
                     child: {
                         foo: '1'
@@ -2400,7 +2400,7 @@ describe(`Dendriform`, () => {
             form.branch(['foo','bar']);
             form.branch(['foo','baz']);
 
-            expect(form.core.nodes).toEqual({
+            expect(form.core.state.nodes).toEqual({
                 '0': {
                     child: {
                         foo: '1'
@@ -2436,7 +2436,7 @@ describe(`Dendriform`, () => {
                 }
             });
 
-            expect(form.core.nodes).toEqual({
+            expect(form.core.state.nodes).toEqual({
                 '0': {
                     child: {
                         foo: '1'
@@ -2472,7 +2472,7 @@ describe(`Dendriform`, () => {
             form.branch(['foo','bar']);
             form.branch(['foo','baz']);
 
-            expect(form.core.nodes).toEqual({
+            expect(form.core.state.nodes).toEqual({
                 '0': {
                     child: {
                         foo: '1'
@@ -2504,7 +2504,7 @@ describe(`Dendriform`, () => {
 
             form.set({});
 
-            expect(form.core.nodes).toEqual({
+            expect(form.core.state.nodes).toEqual({
                 '0': {
                     child: {},
                     id: '0',
@@ -2521,7 +2521,7 @@ describe(`Dendriform`, () => {
             form.branch(1);
             form.branch(0);
 
-            expect(form.core.nodes).toEqual({
+            expect(form.core.state.nodes).toEqual({
                 '0': {
                     child: ['3','2','1'],
                     id: '0',
@@ -2547,7 +2547,7 @@ describe(`Dendriform`, () => {
 
             form.set([123, 456]);
 
-            expect(form.core.nodes).toEqual({
+            expect(form.core.state.nodes).toEqual({
                 '0': {
                     child: ['3','2'],
                     id: '0',
@@ -2573,7 +2573,7 @@ describe(`Dendriform`, () => {
             form.branch([0,'foo']);
             form.branch([1,'foo']);
 
-            expect(form.core.nodes).toEqual({
+            expect(form.core.state.nodes).toEqual({
                 '0': {
                     child: ['1','3'],
                     id: '0',
@@ -2610,7 +2610,7 @@ describe(`Dendriform`, () => {
 
             form.set([{foo: 123}, {foo: 456}], {track: false});
 
-            expect(form.core.nodes).toEqual({
+            expect(form.core.state.nodes).toEqual({
                 '0': {
                     child: ['1','3'],
                     id: '0',

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -1328,6 +1328,28 @@ describe(`Dendriform`, () => {
             expect(callback.mock.calls[0][1].patches.value).toEqual([
                 {op: 'replace', path: [], value: 456}
             ]);
+            expect(callback.mock.calls[0][1].prev).toEqual({
+                value: 123,
+                nodes: {
+                    '0': {
+                        child: undefined,
+                        id: '0',
+                        parentId: '',
+                        type: 0
+                    }
+                }
+            });
+            expect(callback.mock.calls[0][1].next).toEqual({
+                value: 456,
+                nodes: {
+                    '0': {
+                        child: undefined,
+                        id: '0',
+                        parentId: '',
+                        type: 0
+                    }
+                }
+            });
 
             // should not be called if value is the same
             form.set(456);
@@ -1339,6 +1361,28 @@ describe(`Dendriform`, () => {
 
             expect(callback).toHaveBeenCalledTimes(2);
             expect(callback.mock.calls[1][0]).toBe(457);
+            expect(callback.mock.calls[1][1].prev).toEqual({
+                value: 456,
+                nodes: {
+                    '0': {
+                        child: undefined,
+                        id: '0',
+                        parentId: '',
+                        type: 0
+                    }
+                }
+            });
+            expect(callback.mock.calls[1][1].next).toEqual({
+                value: 457,
+                nodes: {
+                    '0': {
+                        child: undefined,
+                        id: '0',
+                        parentId: '',
+                        type: 0
+                    }
+                }
+            });
 
             // should not be called once cancel is called
             cancel();
@@ -1414,7 +1458,25 @@ describe(`Dendriform`, () => {
                 go: 0,
                 patches: {nodes: [], value: []},
                 replace: true,
-                force: false
+                force: false,
+                prev: {
+                    nodes: undefined,
+                    value: undefined
+                },
+                next: {
+                    nodes: {
+                        '0': {
+                            child: {},
+                            id: '0',
+                            parentId: '',
+                            type: 1
+                        }
+                    },
+                    value: {
+                        name: 'boo',
+                        letters: 0
+                    }
+                }
             });
 
             expect(changer).toHaveBeenCalledTimes(1);
@@ -1518,7 +1580,26 @@ describe(`Dendriform`, () => {
                 go: 0,
                 patches: {nodes: [], value: []},
                 replace: true,
-                force: false
+                force: false,
+                prev: {
+                    nodes: undefined,
+                    value: undefined
+                },
+                next: {
+                    nodes: {
+                        '0': {
+                            child: {},
+                            id: '0',
+                            parentId: '',
+                            type: 1
+                        }
+                    },
+                    value: {
+                        name: 'boo',
+                        letters: 0,
+                        lettersDoubled: 0
+                    }
+                }
             });
             expect(form.value).toEqual({
                 name: 'boo',
@@ -1542,7 +1623,34 @@ describe(`Dendriform`, () => {
                 go: 0,
                 patches: {nodes: [], value: []},
                 replace: true,
-                force: false
+                force: false,
+                prev: {
+                    nodes: undefined,
+                    value: undefined
+                },
+                next: {
+                    nodes: {
+                        '0': {
+                            child: {
+                                letters: '1'
+                            },
+                            id: '0',
+                            parentId: '',
+                            type: 1
+                        },
+                        '1': {
+                            child: undefined,
+                            id: '1',
+                            parentId: '0',
+                            type: 0
+                        }
+                    },
+                    value: {
+                        name: 'boo',
+                        letters: 3,
+                        lettersDoubled: 0
+                    }
+                }
             });
             expect(form.value).toEqual({
                 name: 'boo',

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -1185,22 +1185,22 @@ describe(`Dendriform`, () => {
                 expect(wrapper.find('.branch').length).toBe(2);
             });
 
-            //test(`should renderAll es6 set return React element`, () => {
-            //    const form = new Dendriform<Set<string>>(new Set(['foo','bar']));
-//
-            //    const renderer = jest.fn(form => <div className="branch">{form.value}</div>);
-//
-            //    const MyComponent = (props: MyComponentProps<Set<string>>) => {
-            //        return props.form.renderAll(renderer);
-            //    };
-//
-            //    const wrapper = mount(<MyComponent form={form} foo={1} />);
-//
-            //    expect(renderer).toHaveBeenCalledTimes(2);
-            //    expect(renderer.mock.calls[0][0].value).toBe(form.branch('foo').value);
-            //    expect(renderer.mock.calls[1][0].value).toBe(form.branch('bar').value);
-            //    expect(wrapper.find('.branch').length).toBe(2);
-            //});
+            test(`should renderAll es6 set return React element`, () => {
+                const form = new Dendriform<Set<string>>(new Set(['foo','bar']));
+
+                const renderer = jest.fn(form => <div className="branch">{form.value}</div>);
+
+                const MyComponent = (props: MyComponentProps<Set<string>>) => {
+                    return props.form.renderAll(renderer);
+                };
+
+                const wrapper = mount(<MyComponent form={form} foo={1} />);
+
+                expect(renderer).toHaveBeenCalledTimes(2);
+                expect(renderer.mock.calls[0][0].value).toBe(form.branch('foo').value);
+                expect(renderer.mock.calls[1][0].value).toBe(form.branch('bar').value);
+                expect(wrapper.find('.branch').length).toBe(2);
+            });
         });
 
         describe(`react memo and deps`, () => {

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -1463,6 +1463,7 @@ describe(`Dendriform`, () => {
             });
             expect(deriver.mock.calls[0][1]).toEqual({
                 go: 0,
+                id: '0',
                 patches: {nodes: [], value: []},
                 replace: true,
                 force: false,
@@ -1585,6 +1586,7 @@ describe(`Dendriform`, () => {
             });
             expect(deriver1.mock.calls[0][1]).toEqual({
                 go: 0,
+                id: '0',
                 patches: {nodes: [], value: []},
                 replace: true,
                 force: false,
@@ -1628,6 +1630,7 @@ describe(`Dendriform`, () => {
             });
             expect(deriver2.mock.calls[0][1]).toEqual({
                 go: 0,
+                id: '0',
                 patches: {nodes: [], value: []},
                 replace: true,
                 force: false,

--- a/packages/dendriform/test/Nodes.test.ts
+++ b/packages/dendriform/test/Nodes.test.ts
@@ -6,7 +6,7 @@ import produce from 'immer';
 
 const createNodesFrom = (value: unknown, current: number = 0): [Nodes, NewNodeCreator] => {
     const countRef = {current};
-    const newNodeCreator = newNode(countRef);
+    const newNodeCreator = newNode(() => `${countRef.current++}`);
 
     // use immer to add this, because immer freezes things and the tests must cope with that
     const nodes = produce({}, draft => {
@@ -45,27 +45,27 @@ describe(`Nodes`, () => {
                 id: '0'
             };
 
-            expect(newNode(countRef)(undefined)).toEqual(expected);
+            expect(newNode(() => `${countRef.current++}`)(undefined)).toEqual(expected);
             expect(countRef.current).toBe(1);
 
             countRef.current = 0;
-            expect(newNode(countRef)(null)).toEqual(expected);
+            expect(newNode(() => `${countRef.current++}`)(null)).toEqual(expected);
             expect(countRef.current).toBe(1);
 
             countRef.current = 0;
-            expect(newNode(countRef)(1)).toEqual(expected);
+            expect(newNode(() => `${countRef.current++}`)(1)).toEqual(expected);
             expect(countRef.current).toBe(1);
 
             countRef.current = 0;
-            expect(newNode(countRef)('string')).toEqual(expected);
+            expect(newNode(() => `${countRef.current++}`)('string')).toEqual(expected);
             expect(countRef.current).toBe(1);
 
             countRef.current = 0;
-            expect(newNode(countRef)(true)).toEqual(expected);
+            expect(newNode(() => `${countRef.current++}`)(true)).toEqual(expected);
             expect(countRef.current).toBe(1);
 
             countRef.current = 0;
-            expect(newNode(countRef)(NaN)).toEqual(expected);
+            expect(newNode(() => `${countRef.current++}`)(NaN)).toEqual(expected);
             expect(countRef.current).toBe(1);
         });
 
@@ -79,7 +79,7 @@ describe(`Nodes`, () => {
                 bar: 'bar!'
             };
 
-            expect(newNode(countRef)(obj)).toEqual({
+            expect(newNode(() => `${countRef.current++}`)(obj)).toEqual({
                 type: OBJECT,
                 child: {},
                 parentId: '',
@@ -94,7 +94,7 @@ describe(`Nodes`, () => {
 
             const arr = ['a','b','c'];
 
-            expect(newNode(countRef)(arr)).toEqual({
+            expect(newNode(() => `${countRef.current++}`)(arr)).toEqual({
                 type: ARRAY,
                 child: [],
                 parentId: '',
@@ -112,7 +112,7 @@ describe(`Nodes`, () => {
                 [2, 'two']
             ]);
 
-            expect(newNode(countRef)(map)).toEqual({
+            expect(newNode(() => `${countRef.current++}`)(map)).toEqual({
                 type: MAP,
                 child: new Map(),
                 parentId: '',

--- a/packages/dendriform/test/array.test.ts
+++ b/packages/dendriform/test/array.test.ts
@@ -11,7 +11,8 @@ describe(`array`, () => {
             const value = ['a','b','c'];
             const expectedNewValue = ['d','a','b','c'];
 
-            const [newValue, patches, inversePatches] = producePatches(value, array.unshift('d'));
+            const [patches, inversePatches] = producePatches(value, array.unshift('d'));
+            const newValue = applyPatches(value, patches);
 
             expect(newValue).toEqual(expectedNewValue);
             expect(applyPatches(value, patches)).toEqual(expectedNewValue);
@@ -75,7 +76,8 @@ describe(`array`, () => {
             const value = ['a','b','c'];
             const expectedNewValue = ['a','b','c','d'];
 
-            const [newValue, patches, inversePatches] = producePatches(value, array.push('d'));
+            const [patches, inversePatches] = producePatches(value, array.push('d'));
+            const newValue = applyPatches(value, patches);
 
             expect(newValue).toEqual(expectedNewValue);
             expect(applyPatches(value, patches)).toEqual(expectedNewValue);
@@ -110,7 +112,8 @@ describe(`array`, () => {
             const value = ['a','b','c'];
             const expectedNewValue = ['a','b'];
 
-            const [newValue, patches, inversePatches] = producePatches(value, array.pop());
+            const [patches, inversePatches] = producePatches(value, array.pop());
+            const newValue = applyPatches(value, patches);
 
             expect(newValue).toEqual(expectedNewValue);
             expect(applyPatches(value, patches)).toEqual(expectedNewValue);
@@ -142,7 +145,8 @@ describe(`array`, () => {
             const value = ['a','b','c'];
             const expectedNewValue = ['b','c'];
 
-            const [newValue, patches, inversePatches] = producePatches(value, array.shift());
+            const [patches, inversePatches] = producePatches(value, array.shift());
+            const newValue = applyPatches(value, patches);
 
             expect(newValue).toEqual(expectedNewValue);
             expect(applyPatches(value, patches)).toEqual(expectedNewValue);
@@ -171,7 +175,7 @@ describe(`array`, () => {
     describe(`remove`, () => {
 
         test(`with producePatches`, () => {
-            const [, patches, inversePatches] = producePatches('a', array.remove());
+            const [patches, inversePatches] = producePatches('a', array.remove());
             // ignore newValue in this test
             // Dendriform doesnt use it anyway
             expect(patches).toEqual([
@@ -199,7 +203,8 @@ describe(`array`, () => {
             const value = ['a','b','c','d'];
             const expectedNewValue = ['a','d','b','c'];
 
-            const [newValue, patches, inversePatches] = producePatches(value, array.move(3,1));
+            const [patches, inversePatches] = producePatches(value, array.move(3,1));
+            const newValue = applyPatches(value, patches);
 
             expect(newValue).toEqual(expectedNewValue);
             expect(applyPatches(value, patches)).toEqual(expectedNewValue);
@@ -217,7 +222,8 @@ describe(`array`, () => {
             const value = ['a','b','c','d'];
             const expectedNewValue = ['d','a','b','c'];
 
-            const [newValue, patches, inversePatches] = producePatches(value, array.move(3,4));
+            const [patches, inversePatches] = producePatches(value, array.move(3,4));
+            const newValue = applyPatches(value, patches);
 
             expect(newValue).toEqual(expectedNewValue);
             expect(applyPatches(value, patches)).toEqual(expectedNewValue);
@@ -235,7 +241,8 @@ describe(`array`, () => {
             const value = ['a','b','c','d'];
             const expectedNewValue = ['b','c','d','a'];
 
-            const [newValue, patches, inversePatches] = producePatches(value, array.move(0,-1));
+            const [patches, inversePatches] = producePatches(value, array.move(0,-1));
+            const newValue = applyPatches(value, patches);
 
             expect(newValue).toEqual(expectedNewValue);
             expect(applyPatches(value, patches)).toEqual(expectedNewValue);

--- a/packages/dendriform/test/diff.test.ts
+++ b/packages/dendriform/test/diff.test.ts
@@ -299,12 +299,12 @@ describe(`diff`, () => {
         ]);
     });
 
-    test(`array to array 2 without calculating replaced`, () => {
+    test(`array to array 2 without calculating updated`, () => {
         const diffs = diff<string[]|{[key: string]: number}>({
             prev: ARRAY_DATA,
             next: ARRAY_DATA_2,
             id: '0'
-        }, {calculateReplaced: false});
+        }, {calculateUpdated: false});
 
         expect(diffs).toEqual([
             [

--- a/packages/dendriform/test/diff.test.ts
+++ b/packages/dendriform/test/diff.test.ts
@@ -1,0 +1,354 @@
+import {diff} from '../src/index';
+import {BASIC, OBJECT, ARRAY} from 'dendriform-immer-patch-optimiser';
+
+import type {Nodes} from '../src/Nodes';
+
+const SINGLE_NODE = {
+    '0': {
+        child: undefined,
+        id: '0',
+        parentId: '',
+        type: BASIC
+    }
+} as Nodes;
+
+const BASIC_DATA = {
+    value: 100,
+    nodes: SINGLE_NODE
+};
+
+const OBJECT_DATA = {
+    value: {
+        foo: 100,
+        bar: 200,
+        baz: 300
+    },
+    nodes: SINGLE_NODE
+};
+
+const OBJECT_DATA_2 = {
+    value: {
+        bar: 222,
+        baz: 300,
+        qux: 400
+    },
+    nodes: SINGLE_NODE
+};
+
+const ARRAY_DATA = {
+    value: ['a','b','c'],
+    nodes: {
+        '0': {
+            child: ['1','2','3'],
+            id: '0',
+            parentId: '',
+            type: ARRAY
+        },
+        '1': {
+            child: undefined,
+            id: '1',
+            parentId: '',
+            type: BASIC
+        },
+        '2': {
+            child: undefined,
+            id: '2',
+            parentId: '',
+            type: BASIC
+        },
+        '3': {
+            child: undefined,
+            id: '3',
+            parentId: '',
+            type: BASIC
+        }
+    } as Nodes
+};
+
+const ARRAY_DATA_2 = {
+    value: ['b','z','d'],
+    nodes: {
+        '0': {
+            child: ['2','3','4'],
+            id: '0',
+            parentId: '',
+            type: ARRAY
+        },
+        '1': {
+            child: undefined,
+            id: '1',
+            parentId: '',
+            type: BASIC
+        },
+        '2': {
+            child: undefined,
+            id: '2',
+            parentId: '',
+            type: BASIC
+        },
+        '3': {
+            child: undefined,
+            id: '3',
+            parentId: '',
+            type: BASIC
+        }
+    } as Nodes
+};
+
+const DEEP_NODE = {
+    '0': {
+        child: {
+            woo: '1'
+        },
+        id: '0',
+        parentId: '',
+        type: OBJECT
+    },
+    '1': {
+        child: undefined,
+        id: '1',
+        parentId: '',
+        type: OBJECT
+    }
+} as Nodes;
+
+const OBJECT_DATA_DEEP = {
+    value: {
+        // value is already "deep"
+        foo: 100,
+        bar: 200,
+        baz: 300
+    },
+    nodes: DEEP_NODE
+};
+
+const OBJECT_DATA_DEEP_2 = {
+    value: {
+        // value is already "deep"
+        bar: 222,
+        baz: 300,
+        qux: 400
+    },
+    nodes: DEEP_NODE
+};
+
+describe(`diff`, () => {
+    test(`basic to basic`, () => {
+        const diffs = diff({
+            prev: BASIC_DATA,
+            next: BASIC_DATA,
+            id: '0'
+        });
+
+        expect(diffs).toEqual([
+            [],
+            [],
+            []
+        ]);
+    });
+
+    test(`basic to object`, () => {
+        const diffs = diff<number|{[key: string]: number}>({
+            prev: BASIC_DATA,
+            next: OBJECT_DATA,
+            id: '0'
+        });
+
+        expect(diffs).toEqual([
+            [
+                {
+                    key: 'foo',
+                    value: 100
+                },
+                {
+                    key: 'bar',
+                    value: 200
+                },
+                {
+                    key: 'baz',
+                    value: 300
+                }
+            ],
+            [],
+            []
+        ]);
+    });
+
+    test(`object to basic`, () => {
+        const diffs = diff<number|{[key: string]: number}>({
+            prev: OBJECT_DATA,
+            next: BASIC_DATA,
+            id: '0'
+        });
+
+        expect(diffs).toEqual([
+            [],
+            [
+                {
+                    key: 'foo',
+                    value: 100
+                },
+                {
+                    key: 'bar',
+                    value: 200
+                },
+                {
+                    key: 'baz',
+                    value: 300
+                }
+            ],
+            []
+        ]);
+    });
+
+    test(`object to object 2`, () => {
+        const diffs = diff<{[key: string]: number}>({
+            prev: OBJECT_DATA,
+            next: OBJECT_DATA_2,
+            id: '0'
+        });
+
+        expect(diffs).toEqual([
+            [
+                {
+                    key: 'qux',
+                    value: 400
+                }
+            ],
+            [
+                {
+                    key: 'foo',
+                    value: 100
+                }
+            ],
+            [
+                {
+                    key: 'bar',
+                    value: 222
+                }
+            ]
+        ]);
+    });
+
+    test(`object to array`, () => {
+        const diffs = diff<string[]|{[key: string]: number}>({
+            prev: OBJECT_DATA,
+            next: ARRAY_DATA,
+            id: '0'
+        });
+
+        expect(diffs).toEqual([
+            [
+                {
+                    key: 0,
+                    value: 'a'
+                },
+                {
+                    key: 1,
+                    value: 'b'
+                },
+                {
+                    key: 2,
+                    value: 'c'
+                }
+            ],
+            [
+                {
+                    key: 'foo',
+                    value: 100
+                },
+                {
+                    key: 'bar',
+                    value: 200
+                },
+                {
+                    key: 'baz',
+                    value: 300
+                }
+            ],
+            []
+        ]);
+    });
+
+    test(`array to array 2`, () => {
+        const diffs = diff<string[]|{[key: string]: number}>({
+            prev: ARRAY_DATA,
+            next: ARRAY_DATA_2,
+            id: '0'
+        });
+
+        expect(diffs).toEqual([
+            [
+                {
+                    key: 2,
+                    value: 'd'
+                }
+            ],
+            [
+                {
+                    key: 0,
+                    value: 'a'
+                }
+            ],
+            [
+                {
+                    key: 1,
+                    value: 'z'
+                }
+            ]
+        ]);
+    });
+
+    test(`array to array 2 without calculating replaced`, () => {
+        const diffs = diff<string[]|{[key: string]: number}>({
+            prev: ARRAY_DATA,
+            next: ARRAY_DATA_2,
+            id: '0'
+        }, {calculateReplaced: false});
+
+        expect(diffs).toEqual([
+            [
+                {
+                    key: 2,
+                    value: 'd'
+                }
+            ],
+            [
+                {
+                    key: 0,
+                    value: 'a'
+                }
+            ],
+            []
+        ]);
+    });
+
+    test(`object to object 2 deep`, () => {
+        const diffs = diff<{[key: string]: number}>({
+            prev: OBJECT_DATA_DEEP,
+            next: OBJECT_DATA_DEEP_2,
+            id: '1'
+        });
+
+        expect(diffs).toEqual([
+            [
+                {
+                    key: 'qux',
+                    value: 400
+                }
+            ],
+            [
+                {
+                    key: 'foo',
+                    value: 100
+                }
+            ],
+            [
+                {
+                    key: 'bar',
+                    value: 222
+                }
+            ]
+        ]);
+    });
+});

--- a/packages/dendriform/test/errors.test.ts
+++ b/packages/dendriform/test/errors.test.ts
@@ -4,8 +4,8 @@ describe(`die`, () => {
     test(`should throw errors`, () => {
         expect(() => die(0, 123)).toThrow(`[Dendriform] Cannot find path of node 123`);
         // expect(() => die(1, ['a',1])).toThrow(`[Dendriform] Cannot find node at path ["a",1]`);
-        expect(() => die(2)).toThrow(`[Dendriform] branchAll() can only be called on forms containing arrays`);
-        expect(() => die(3)).toThrow(`[Dendriform] renderAll() can only be called on forms containing arrays`);
+        expect(() => die(2)).toThrow(`[Dendriform] branchAll() can only be called on forms containing an array, object, es6 map or es6 set`);
+        expect(() => die(3)).toThrow(`[Dendriform] renderAll() can only be called on forms containing an array, object, es6 map or es6 set`);
         expect(() => die(4, ['foo'])).toThrow(`[Dendriform] useIndex() can only be called on array element forms, can't be called at path [\"foo\"]`);
     });
 

--- a/packages/dendriform/test/producePatches.test.ts
+++ b/packages/dendriform/test/producePatches.test.ts
@@ -1,23 +1,23 @@
 import {producePatches, patches} from '../src/index';
+import {applyPatches} from 'dendriform-immer-patch-optimiser';
 
 describe(`producePatches`, () => {
 
     describe(`accepting a value`, () => {
         test(`should accept a value and output patches`, () => {
-            expect(producePatches(1, 2)[0]).toEqual(2);
-            expect(producePatches(1, 2)[1]).toEqual([{op: 'replace', path: [], value: 2}]);
-            expect(producePatches(1, 2)[2]).toEqual([{op: 'replace', path: [], value: 1}]);
+            expect(producePatches(1, 2)[0]).toEqual([{op: 'replace', path: [], value: 2}]);
+            expect(producePatches(1, 2)[1]).toEqual([{op: 'replace', path: [], value: 1}]);
 
-            expect(producePatches('strong', 'string')[1]).toEqual([{op: 'replace', path: [], value: 'string'}]);
-            expect(producePatches(1, undefined)[1]).toEqual([{op: 'replace', path: [], value: undefined}]);
-            expect(producePatches(1, null)[1]).toEqual([{op: 'replace', path: [], value: null}]);
-            expect(producePatches({}, {foo: true})[1]).toEqual([{op: 'replace', path: [], value: {foo: true}}]);
-            expect(producePatches([1], [])[1]).toEqual([{op: 'replace', path: ['length'], value: 0}]);
-            expect(producePatches([1], [2])[1]).toEqual([
+            expect(producePatches('strong', 'string')[0]).toEqual([{op: 'replace', path: [], value: 'string'}]);
+            expect(producePatches(1, undefined)[0]).toEqual([{op: 'replace', path: [], value: undefined}]);
+            expect(producePatches(1, null)[0]).toEqual([{op: 'replace', path: [], value: null}]);
+            expect(producePatches({}, {foo: true})[0]).toEqual([{op: 'replace', path: [], value: {foo: true}}]);
+            expect(producePatches([1], [])[0]).toEqual([{op: 'replace', path: ['length'], value: 0}]);
+            expect(producePatches([1], [2])[0]).toEqual([
                 {op: 'replace', path: ['length'], value: 0},
                 {op: 'add', path: [0], value: 2}
             ]);
-            expect(producePatches([{op: 1}], [{op: 2}])[1]).toEqual([
+            expect(producePatches([{op: 1}], [{op: 2}])[0]).toEqual([
                 {op: 'replace', path: ['length'], value: 0},
                 {op: 'add', path: [0], value: {op: 2}}
             ]);
@@ -26,12 +26,12 @@ describe(`producePatches`, () => {
 
     describe(`accepting an immer producer`, () => {
         test(`should accept an immer producer`, () => {
-
-            const [newValue, patches, inversePatches] = producePatches(['a'], draft => {
+            const base = ['a'];
+            const [patches, inversePatches] = producePatches(base, draft => {
                 draft.push('b');
             });
 
-            expect(newValue).toEqual(['a','b']);
+            expect(applyPatches(base, patches)).toEqual(['a','b']);
             expect(patches).toEqual([
                 {op: 'add', path: [1], value: 'b'}
             ]);
@@ -47,12 +47,12 @@ describe(`producePatches`, () => {
                 {name: 'b'}
             ];
 
-            const [newValue, patches, inversePatches] = producePatches(base, draft => {
+            const [patches, inversePatches] = producePatches(base, draft => {
                 draft.unshift({name: 'c'});
                 draft.reverse();
             });
 
-            expect(newValue).toEqual([
+            expect(applyPatches(base, patches)).toEqual([
                 {name: 'b'},
                 {name: 'a'},
                 {name: 'c'}
@@ -74,7 +74,9 @@ describe(`producePatches`, () => {
 
         test(`should accept a patch pair and output them`, () => {
 
-            const [newValue, patches, inversePatches] = producePatches(['a','b','c'], {
+            const base = ['a','b','c'];
+
+            const [patches, inversePatches] = producePatches(base, {
                 __patches: (base) => [
                     {op: 'remove', path: [base.length - 1]}
                 ],
@@ -83,7 +85,7 @@ describe(`producePatches`, () => {
                 ]
             });
 
-            expect(newValue).toEqual(['a','b']);
+            expect(applyPatches(base, patches)).toEqual(['a','b']);
 
             expect(patches).toEqual([
                 {op: 'remove', path: [2]}


### PR DESCRIPTION
- Add cancel feature (`onDerive`s can throw a cancel to have a change cancelled) #50 
- Add `diff` #51 
- Add support for es6 Sets
- Let `branchAll()` and `renderAll()` work on objects, es6 maps and es6 sets
- Add `.key`
- Add details to change and derive callbacks
- Fix #45 
- Chained change callbacks now all occur after derive
