### PR TITLE
break: reshape pluginsubmit api, store error state in plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1175,15 +1175,16 @@ The `onSubmit` function passes the same `details` object as `onChange` does, so 
 import {PluginSubmit} from 'dendriform';
 
 const plugins = {
-    submit: new PluginSubmit({
-        onSubmit: async (newValue, details) => {
+    submit: new PluginSubmit<V,E>({
+        onSubmit: async (newValue, details): void => {
             // trigger save action here
             // any errors will be eligible for resubmission
             // diff(details) can be used in here to diff changes since last submit
         },
-        onError: (error) => {
-            // optional function, will be called
-            // if an error occurs in onSubmit
+        onError: (error: any): E|undefined => {
+            // optional function, will be called if an error occurs in onSubmit
+            // anything returned will be stored in state in form.plugins.submit.error
+            // the error state is cleared on next submit
         }
     })
 };
@@ -1204,12 +1205,12 @@ form.branch('foo').plugins.submit.changed;
 PluginSubmit has the following properties and methods.
 
 - `submit(): void` - submits the form if there are changes, calling `onSubmit`. If the value of the form has not changed then this has no effect.
-- `previous: V` - the inital value / the value of the previous submit at the current branch.
-- `usePrevous(): V` - a React hook returning the inital value / the value of the previous submit at the current branch.
-- `dirty: boolean` - a boolean indicating if the value at the current branch is dirty i.e. has changed.
-- `useDirty(): boolean` - a React hook returning a boolean indicating if the value at the current branch is dirty i.e. has changed.
-- `submitting: boolean` - a boolean stating if the plugin is currently waiting for an async `onSubmit` call to complete.
-- `useSubmitting(): boolean` - a React hook returning a boolean stating if the plugin is currently waiting for an async `onSubmit` call to complete.
+- `previous: Dendriform<V>` - a dendriform containing the inital value / the value of the previous submit at the current branch.
+- `submitting: Dendriform<boolean>` - a dendriform containing a boolean stating if the plugin is currently waiting for an async `onSubmit` call to complete.
+- `submitting: Dendriform<E|undefined>` - a dendriform containing the most recent result of `onError`. This is changed to `undefined` on submit.
+- `dirty.value: boolean` - a boolean indicating if the value at the current branch is dirty i.e. has changed.
+- `dirty.useValue(): boolean` - a React hook returning a boolean indicating if the value at the current branch is dirty i.e. has changed.
+
 
 ## Advanced usage
 

--- a/packages/dendriform-demo/components/Demos.tsx
+++ b/packages/dendriform-demo/components/Demos.tsx
@@ -1489,7 +1489,7 @@ type SubmitValue = {
 };
 
 type SubmitPlugins = {
-    submit: PluginSubmit<SubmitValue>;
+    submit: PluginSubmit<SubmitValue,string>;
 };
 
 const causeAnErrorForm = new Dendriform(false);

--- a/packages/dendriform-demo/components/Demos.tsx
+++ b/packages/dendriform-demo/components/Demos.tsx
@@ -1492,10 +1492,15 @@ type SubmitPlugins = {
     submit: PluginSubmit<SubmitValue>;
 };
 
+const causeAnErrorForm = new Dendriform(false);
+
 async function fakeSave(value: SubmitValue): Promise<void> {
     // eslint-disable-next-line no-console
     console.log('saving', value);
     await new Promise(r => setTimeout(r, 1000));
+    if(causeAnErrorForm.value) {
+        throw new Error('Error!');
+    }
     // eslint-disable-next-line no-console
     console.log('saved');
 }
@@ -1511,7 +1516,8 @@ function PluginSubmitExample(): React.ReactElement {
         submit: new PluginSubmit({
             onSubmit: async (newValue: SubmitValue) => {
                 await fakeSave(newValue);
-            }
+            },
+            onError: e => e.message
         })
     });    
 
@@ -1525,30 +1531,49 @@ function PluginSubmitExample(): React.ReactElement {
     return <Region>
         <form onSubmit={onSubmit}>
             {form.render('firstName', form => {
-                const hasChanged = form.plugins.submit.useDirty();
+                const hasChanged = form.plugins.submit.dirty.useValue();
                 return <Region of="label">first name: <input {...useInput(form, 150)} /> {hasChanged ? '*' : ''}</Region>;
             })}
 
             {form.render('lastName', form => {
-                const hasChanged = form.plugins.submit.useDirty();
+                const hasChanged = form.plugins.submit.dirty.useValue();
                 return <Region of="label">last name: <input {...useInput(form, 150)} /> {hasChanged ? '*' : ''}</Region>;
             })}
 
             {form.render(form => {
-                const submitting = form.plugins.submit.useSubmitting();
+                const submitting = form.plugins.submit.submitting.useValue();
                 return <Region>
-                    <button type="submit" disabled={!form.plugins.submit.useDirty()}>Submit</button>
+                    <button type="submit" disabled={!form.plugins.submit.dirty.useValue()}>Submit</button>
                     {submitting && <span>Saving...</span>}
                 </Region>;
             })}
+
+            {form.plugins.submit.error.render(form => {
+                const error = form.useValue();
+                return <Region>
+                    {error && <code>{error}</code>}
+                </Region>;
+            })}
         </form>
+
+        {causeAnErrorForm.render(form => (
+            <Region of="label">
+                cause an error on submit
+                <input type="checkbox" {...useCheckbox(form)} />
+            </Region>
+        ))}
     </Region>;
 }
 
 const PluginSubmitExampleCode = `
+const causeAnErrorForm = new Dendriform(false);
+
 async function fakeSave(value) {
     console.log('saving', value);
     await new Promise(r => setTimeout(r, 1000));
+    if(causeAnErrorForm.value) {
+        throw new Error('Error!');
+    }
     console.log('saved');
 }
 
@@ -1574,25 +1599,39 @@ function PluginSubmitExample() {
         form.plugins.submit.submit();
     }, []);
 
-    return <form onSubmit={onSubmit}>
-        {form.render('firstName', form => {
-            const hasChanged = form.plugins.submit.useDirty();
-            return <label>first name: <input {...useInput(form, 150)} /> {hasChanged ? '*' : ''}</label>;
-        })}
+    return <>
+        <form onSubmit={onSubmit}>
+            {form.render('firstName', form => {
+                const hasChanged = form.plugins.submit.dirty.useValue();
+                return <label>first name: <input {...useInput(form, 150)} /> {hasChanged ? '*' : ''}</label>;
+            })}
 
-        {form.render('lastName', form => {
-            const hasChanged = form.plugins.submit.useDirty();
-            return <label>last name: <input {...useInput(form, 150)} /> {hasChanged ? '*' : ''}</label>;
-        })}
+            {form.render('lastName', form => {
+                const hasChanged = form.plugins.submit.dirty.useValue();
+                return <label>last name: <input {...useInput(form, 150)} /> {hasChanged ? '*' : ''}</label>;
+            })}
 
-        {form.render(form => {
-            const submitting = form.plugins.submit.useSubmitting();
-            return <>
-                <button type="submit" disabled={!form.plugins.submit.useDirty()}>Submit</button>
-                {submitting && <span>Saving...</span>}
-            </>;
-        })}
-    </form>;
+            {form.render(form => {
+                const submitting = form.plugins.submit.useSubmitting();
+                return <>
+                    <button type="submit" disabled={!form.plugins.submit.dirty.useValue()}>Submit</button>
+                    {submitting && <span>Saving...</span>}
+                </>;
+            })}
+
+            {form.plugins.submit.error.render(form => {
+                const error = form.useValue();
+                return <>{error && <code>{error}</code>}</>;
+            })}
+        </form>
+
+        {causeAnErrorForm.render(form => (
+            <label>
+                cause an error on submit
+                <input type="checkbox" {...useCheckbox(form)} />
+            </label>
+        ))}
+    </>;
 }
 `;
 
@@ -2585,7 +2624,10 @@ const DEMOS: DemoObject[] = [
         description: `An example of how one might implement drag and drop with react-beautiful-dnd. Dendriform's .renderAll() function, and its automatic id management on array elements simplifies this greatly.`,
         anchor: 'draganddrop',
         more: 'drag-and-drop'
-    },
+    }
+];
+
+const PLUGIN_DEMOS: DemoObject[] = [
     {
         title: 'Submit Plugin (PluginSubmit)',
         Demo: PluginSubmitExample,
@@ -2664,6 +2706,12 @@ const ADVANCED_DEMOS: DemoObject[] = [
 export function Demos(): React.ReactElement {
     return <Flex flexWrap="wrap">
         {DEMOS.map(demo => <Demo demo={demo} key={demo.anchor} />)}
+    </Flex>;
+}
+
+export function PluginDemos(): React.ReactElement {
+    return <Flex flexWrap="wrap">
+        {PLUGIN_DEMOS.map(demo => <Demo demo={demo} key={demo.anchor} />)}
     </Flex>;
 }
 

--- a/packages/dendriform-demo/pages/index.tsx
+++ b/packages/dendriform-demo/pages/index.tsx
@@ -2,7 +2,7 @@
 import styled from 'styled-components';
 import {Box, Flex, Wrapper, FloatZone} from '../components/Layout';
 import {Text, H1, Link} from '../components/Text';
-import {Demos, AdvancedDemos} from '../components/Demos';
+import {Demos, PluginDemos, AdvancedDemos} from '../components/Demos';
 import type {ThemeProps} from '../pages/_app';
 
 export default function Main(): React.ReactElement {
@@ -34,6 +34,13 @@ export default function Main(): React.ReactElement {
         </Box>
         <Box mb={5}>
             <Demos />
+        </Box>
+        <Hr />
+        <Box mb={3}>
+            <H1>Plugin Demos</H1>
+        </Box>
+        <Box mb={3}>
+            <PluginDemos />
         </Box>
         <Hr />
         <Box mb={3}>

--- a/packages/dendriform/README.md
+++ b/packages/dendriform/README.md
@@ -1175,15 +1175,16 @@ The `onSubmit` function passes the same `details` object as `onChange` does, so 
 import {PluginSubmit} from 'dendriform';
 
 const plugins = {
-    submit: new PluginSubmit({
-        onSubmit: async (newValue, details) => {
+    submit: new PluginSubmit<V,E>({
+        onSubmit: async (newValue, details): void => {
             // trigger save action here
             // any errors will be eligible for resubmission
             // diff(details) can be used in here to diff changes since last submit
         },
-        onError: (error) => {
-            // optional function, will be called
-            // if an error occurs in onSubmit
+        onError: (error: any): E|undefined => {
+            // optional function, will be called if an error occurs in onSubmit
+            // anything returned will be stored in state in form.plugins.submit.error
+            // the error state is cleared on next submit
         }
     })
 };
@@ -1204,12 +1205,12 @@ form.branch('foo').plugins.submit.changed;
 PluginSubmit has the following properties and methods.
 
 - `submit(): void` - submits the form if there are changes, calling `onSubmit`. If the value of the form has not changed then this has no effect.
-- `previous: V` - the inital value / the value of the previous submit at the current branch.
-- `usePrevous(): V` - a React hook returning the inital value / the value of the previous submit at the current branch.
-- `dirty: boolean` - a boolean indicating if the value at the current branch is dirty i.e. has changed.
-- `useDirty(): boolean` - a React hook returning a boolean indicating if the value at the current branch is dirty i.e. has changed.
-- `submitting: boolean` - a boolean stating if the plugin is currently waiting for an async `onSubmit` call to complete.
-- `useSubmitting(): boolean` - a React hook returning a boolean stating if the plugin is currently waiting for an async `onSubmit` call to complete.
+- `previous: Dendriform<V>` - a dendriform containing the inital value / the value of the previous submit at the current branch.
+- `submitting: Dendriform<boolean>` - a dendriform containing a boolean stating if the plugin is currently waiting for an async `onSubmit` call to complete.
+- `submitting: Dendriform<E|undefined>` - a dendriform containing the most recent result of `onError`. This is changed to `undefined` on submit.
+- `dirty.value: boolean` - a boolean indicating if the value at the current branch is dirty i.e. has changed.
+- `dirty.useValue(): boolean` - a React hook returning a boolean indicating if the value at the current branch is dirty i.e. has changed.
+
 
 ## Advanced usage
 

--- a/packages/dendriform/src/plugins/PluginSubmit.ts
+++ b/packages/dendriform/src/plugins/PluginSubmit.ts
@@ -9,7 +9,8 @@ const isPromise = (thing: any): thing is Promise<unknown> => {
 };
 
 export type PluginSubmitOnSubmit<V> = (newValue: V, details: ChangeCallbackDetails<V>) => void|Promise<void>;
-export type PluginSubmitOnError<E> = (error: unknown) => E|undefined;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PluginSubmitOnError<E> = (error: any) => E|undefined;
 
 export type PluginSubmitConfig<V,E> = {
     onSubmit: PluginSubmitOnSubmit<V>;

--- a/packages/dendriform/test/plugins/PluginSubmit.test.ts
+++ b/packages/dendriform/test/plugins/PluginSubmit.test.ts
@@ -59,17 +59,17 @@ describe(`plugin submit`, () => {
 
         const form = new Dendriform(value, {plugins});
 
-        expect(form.plugins.submit.dirty).toBe(false);
-        expect(form.branch('foo').plugins.submit.dirty).toBe(false);
-        expect(form.branch('bar').plugins.submit.dirty).toBe(false);
+        expect(form.plugins.submit.dirty.value).toBe(false);
+        expect(form.branch('foo').plugins.submit.dirty.value).toBe(false);
+        expect(form.branch('bar').plugins.submit.dirty.value).toBe(false);
 
         form.branch('foo').set(456);
 
-        expect(form.plugins.submit.previous).toEqual({foo: 123, bar: 456});
-        expect(form.branch('foo').plugins.submit.previous).toBe(123);
-        expect(form.plugins.submit.dirty).toBe(true);
-        expect(form.branch('foo').plugins.submit.dirty).toBe(true);
-        expect(form.branch('bar').plugins.submit.dirty).toBe(false);
+        expect(form.plugins.submit.previous.value).toEqual({foo: 123, bar: 456});
+        expect(form.branch('foo').plugins.submit.previous.value).toBe(123);
+        expect(form.plugins.submit.dirty.value).toBe(true);
+        expect(form.branch('foo').plugins.submit.dirty.value).toBe(true);
+        expect(form.branch('bar').plugins.submit.dirty.value).toBe(false);
     });
 
     test(`should not submit value if not changed - this behaviour may change in future`, () => {
@@ -153,7 +153,7 @@ describe(`plugin submit`, () => {
             draft.bar = 200;
         });
 
-        expect(form.plugins.submit.previous).toEqual({
+        expect(form.plugins.submit.previous.value).toEqual({
             foo: 100
         });
 
@@ -168,7 +168,7 @@ describe(`plugin submit`, () => {
             foo: 100
         });
 
-        expect(form.plugins.submit.previous).toEqual({
+        expect(form.plugins.submit.previous.value).toEqual({
             foo: 100,
             bar: 200
         });
@@ -188,7 +188,7 @@ describe(`plugin submit`, () => {
             bar: 200
         });
 
-        expect(form.plugins.submit.previous).toEqual({
+        expect(form.plugins.submit.previous.value).toEqual({
             bar: 200
         });
     });
@@ -200,7 +200,7 @@ describe(`plugin submit`, () => {
         };
 
         const mockSubmit = jest.fn();
-        const onError = jest.fn();
+        const onError = jest.fn(e => e.message);
         let called = 0;
         
         const plugins = {
@@ -229,9 +229,12 @@ describe(`plugin submit`, () => {
             bar: 200
         });
         expect(onError).toHaveBeenCalledTimes(1);
+
+        // error should contain error
+        expect(form.plugins.submit.error.value).toBe('!');
         
         // previous should not be updated
-        expect(form.plugins.submit.previous).toEqual({
+        expect(form.plugins.submit.previous.value).toEqual({
             foo: 100
         });
 
@@ -243,10 +246,11 @@ describe(`plugin submit`, () => {
             bar: 200
         });
         expect(onError).toHaveBeenCalledTimes(1);
-        expect(form.plugins.submit.previous).toEqual({
+        expect(form.plugins.submit.previous.value).toEqual({
             foo: 100,
             bar: 200
         });
+        expect(form.plugins.submit.error.value).toBe(undefined);
     });
 
     test(`should use async onSubmit`, async () => {
@@ -275,13 +279,13 @@ describe(`plugin submit`, () => {
             });
         });
 
-        expect(form.plugins.submit.submitting).toBe(false);
+        expect(form.plugins.submit.submitting.value).toBe(false);
 
         form.plugins.submit.submit();
 
         // async, so not called yet
         expect(mockDiffed).toHaveBeenCalledTimes(0);
-        expect(form.plugins.submit.submitting).toBe(true);
+        expect(form.plugins.submit.submitting.value).toBe(true);
 
         // resolve promises
         await Promise.resolve();
@@ -289,7 +293,7 @@ describe(`plugin submit`, () => {
 
         expect(mockDiffed).toHaveBeenCalledTimes(1);
         expect(mockDiffed.mock.calls[0][0][0].length).toBe(1);
-        expect(form.plugins.submit.submitting).toBe(false);
+        expect(form.plugins.submit.submitting.value).toBe(false);
     });
 
     test(`should use async onSubmit and reject`, async () => {
@@ -300,7 +304,7 @@ describe(`plugin submit`, () => {
             }
         ];
 
-        const onError = jest.fn();
+        const onError = jest.fn(() => '!!!');
         
         const plugins = {
             submit: new PluginSubmit({
@@ -324,6 +328,7 @@ describe(`plugin submit`, () => {
         await Promise.resolve();
 
         expect(onError).toHaveBeenCalledTimes(1);
-        expect(form.plugins.submit.submitting).toBe(false);
+        expect(form.plugins.submit.error.value).toBe('!!!');
+        expect(form.plugins.submit.submitting.value).toBe(false);
     });
 });


### PR DESCRIPTION
## Breaking changes
- `PluginSubmit.previousForm` -> `PluginSubmit.previous`
- `PluginSubmit.previous` -> `PluginSubmit.previous.value`
- `PluginSubmit.usePrevious` -> `PluginSubmit.previous.useValue()`
- `PluginSubmit.submittingForm` -> `PluginSubmit.submitting`
- `PluginSubmit.submitting` -> `PluginSubmit.submitting.value`
- `PluginSubmit.useSubmitting` -> `PluginSubmit.submitting.useValue()`
- `PluginSubmit.dirty` -> `PluginSubmit.dirty.value`
- `PluginSubmit.useDirty` -> `PluginSubmit.dirty.useValue()`

## Features
- `PluginSubmit` now stores most recent error state in  `PluginSubmit.error`