### PR TITLE
Fix PluginSubmit dirty strict equality issue

### DIFF
--- a/packages/dendriform-immer-patch-optimiser/test/optimise.test.ts
+++ b/packages/dendriform-immer-patch-optimiser/test/optimise.test.ts
@@ -37,6 +37,20 @@ function runTest<B>(
     });
 }
 
+describe(`strictly equal to input`, () => {
+    const base: number[] = [];
+    const arr = [1,2,3];
+
+    const [result, recordedPatches] = produceWithPatches(base, () => arr);
+    expect(result).toEqual(arr);
+    expect(result).toBe(arr);
+
+    const optimisedPatches = optimise(base, recordedPatches);
+    expect(applyPatches(base, optimisedPatches)).toEqual(arr);
+    expect(applyPatches(base, optimisedPatches)).toBe(arr);
+});
+
+
 describe(`pop`, () => {
     runTest(
         ['a','b','c'],

--- a/packages/dendriform-immer-patch-optimiser/test/optimise.test.ts
+++ b/packages/dendriform-immer-patch-optimiser/test/optimise.test.ts
@@ -37,20 +37,6 @@ function runTest<B>(
     });
 }
 
-describe(`strictly equal to input`, () => {
-    const base: number[] = [];
-    const arr = [1,2,3];
-
-    const [result, recordedPatches] = produceWithPatches(base, () => arr);
-    expect(result).toEqual(arr);
-    expect(result).toBe(arr);
-
-    const optimisedPatches = optimise(base, recordedPatches);
-    expect(applyPatches(base, optimisedPatches)).toEqual(arr);
-    expect(applyPatches(base, optimisedPatches)).toBe(arr);
-});
-
-
 describe(`pop`, () => {
     runTest(
         ['a','b','c'],

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -51,6 +51,20 @@ describe(`Dendriform`, () => {
             expect(form.id).toBe('0');
         });
 
+        test(`should set object value and be strictly equal`, () => {
+            const form = new Dendriform({foo: false});
+            const obj = {foo: true};
+            form.set(obj);
+            expect(form.value).toBe(obj);
+        });
+
+        test(`should set array value and be strictly equal`, () => {
+            const form = new Dendriform([123,456]);
+            const arr = [456,789];
+            form.set(arr);
+            expect(form.value).toBe(arr);
+        });
+
         test(`should set value from immer producer`, () => {
             const form = new Dendriform(1);
 

--- a/packages/dendriform/test/Dendriform.test.tsx
+++ b/packages/dendriform/test/Dendriform.test.tsx
@@ -58,10 +58,17 @@ describe(`Dendriform`, () => {
             expect(form.value).toBe(obj);
         });
 
-        test(`should set array value and be strictly equal`, () => {
+        test(`should set array value and NOT be strictly equal when tracking is on`, () => {
             const form = new Dendriform([123,456]);
             const arr = [456,789];
             form.set(arr);
+            expect(form.value).not.toBe(arr);
+        });
+
+        test(`should set array value and be strictly equal when tracking is off`, () => {
+            const form = new Dendriform([123,456]);
+            const arr = [456,789];
+            form.set(arr, {track: false});
             expect(form.value).toBe(arr);
         });
 

--- a/packages/dendriform/test/plugins/PluginSubmit.test.ts
+++ b/packages/dendriform/test/plugins/PluginSubmit.test.ts
@@ -174,6 +174,7 @@ describe(`plugin submit`, () => {
         expect(form.plugins.submit.previous.value).toEqual({
             foo: 100
         });
+        expect(form.plugins.submit.dirty.value).toBe(true);
 
         form.plugins.submit.submit();
 
@@ -190,6 +191,7 @@ describe(`plugin submit`, () => {
             foo: 100,
             bar: 200
         });
+        expect(form.plugins.submit.dirty.value).toBe(false);
 
         form.set(draft => {
             delete draft.foo;
@@ -209,6 +211,36 @@ describe(`plugin submit`, () => {
         expect(form.plugins.submit.previous.value).toEqual({
             bar: 200
         });
+    });
+
+    test(`should update previous state after successful submit of array`, () => {
+
+        const value: string[] = ['a'];
+
+        const onSubmit = jest.fn();
+        
+        const plugins = {
+            submit: new PluginSubmit({
+                onSubmit
+            })
+        };
+
+        const form = new Dendriform(value, {plugins});
+        form.set(draft => {
+            draft.push('b');
+        });
+
+        expect(form.plugins.submit.previous.value).toEqual(['a']);
+        expect(form.plugins.submit.dirty.value).toBe(true);
+
+        form.plugins.submit.submit();
+
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit.mock.calls[0][0]).toEqual(['a', 'b']);
+        expect(onSubmit.mock.calls[0][1].prev.value).toEqual(['a']);
+
+        expect(form.plugins.submit.previous.value).toEqual(['a', 'b']);
+        expect(form.plugins.submit.dirty.value).toBe(false);
     });
 
     test(`should rollback and allow second attempt if onSubmit throws an error`, () => {


### PR DESCRIPTION
When using `PluginSubmit` with an array, `dirty` was not being reset correctly. This is because the plugin was using strict equality to check if the value of one form was equal to the contents of another. This is often fine, but arrays are optimised and so the results may be equal by value but not strictly equal. Tracking might be considered to be turned off for pluginsubmit to resolve this, but then diff() on the submission would not work.

Currently there is no way to `form.set(array)` and have `array === form.value` _while also_ having correct diffs. Diffs require the optimisation. Perhaps in future a new type of dendriform patch type could be introduced like a `replace` patch but without changing any nodes, whose value is strictly equal to the new value, and this could be appended after all the normal optimised patches to replace `form.value` with the original array instance.